### PR TITLE
Wrap the simulation data from within each backend

### DIFF
--- a/pysages/backends/core.py
+++ b/pysages/backends/core.py
@@ -53,7 +53,7 @@ def view(backend, simulation):
 def _set_bias(backend, simulation):
     # Depending on the device being used we need to use either cupy or numpy
     # (or numba) to generate a view of jax's DeviceArrays
-    if backend.get_device_type(simulation) == "gpu":
+    if backend.is_on_gpu(simulation):
         cupy = importlib.import_module("cupy")
         wrap = cupy.asarray
     else:


### PR DESCRIPTION
Wrapping the data into JAX's DeviceArrays should be handled by each pysages's backend given the differences in how data is exposed from MD engine to MD engine. 