### PR TITLE
API clean up: Do not require passing the backend

### DIFF
--- a/pysages/__init__.py
+++ b/pysages/__init__.py
@@ -3,9 +3,10 @@
 
 
 from .backends import (
-    link,
+    bind,
     set_backend,
-    view,
+    supported_backends,
+    wrap,
 )
 
 from .ssages import (

--- a/pysages/backends/__init__.py
+++ b/pysages/backends/__init__.py
@@ -2,10 +2,10 @@
 # Copyright (c) 2020: Pablo Zubieta (see LICENSE.md)
 
 
-from .api import (
-    active_backend,
-    link,
+from .core import (
+    bind,
+    current_backend,
     set_backend,
     supported_backends,
-    view,
+    wrap,
 )

--- a/pysages/backends/api.py
+++ b/pysages/backends/api.py
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2020: Pablo Zubieta (see LICENSE.md)
-
-
-from .core import (
-    active_backend, link, set_backend, supported_backends, view,
-)

--- a/pysages/backends/core.py
+++ b/pysages/backends/core.py
@@ -4,6 +4,7 @@
 
 import importlib
 import jax
+import warnings
 
 from jax import numpy as np
 from pysages.ssages import Box, SystemView
@@ -14,11 +15,13 @@ jax.config.update("jax_enable_x64", True)
 
 
 # Records the backend selected with `set_backend`
-_ACTIVE_BACKEND = None
+_CURRENT_BACKEND = None
 
 
-def active_backend():
-    return _ACTIVE_BACKEND
+def current_backend():
+    if _CURRENT_BACKEND is not None:
+        return _CURRENT_BACKEND
+    warnings.warn("No backend has been set")
 
 
 def supported_backends():
@@ -28,32 +31,35 @@ def supported_backends():
 def set_backend(name):
     """To see a list of possible backends run `supported_backends()`."""
     #
-    global _ACTIVE_BACKEND
+    global _CURRENT_BACKEND
     #
     if name in supported_backends():
-        _ACTIVE_BACKEND = importlib.import_module('.hoomd', package="pysages.backends")
+        _CURRENT_BACKEND = importlib.import_module('.' + name, package="pysages.backends")
     else:
-        raise ValueError('Invalid backend')
+        raise ValueError("Invalid backend")
     #
-    return _ACTIVE_BACKEND
+    return _CURRENT_BACKEND
 
 
-def view(backend, simulation):
+def wrap(simulation):
     """Create a view of the simulation data (dynamic snapshot) for the provided backend."""
     #
-    if not backend.is_on_gpu(simulation):
+    if _CURRENT_BACKEND is None:
+        raise RuntimeError("No backend has been set")
+    #
+    if not _CURRENT_BACKEND.is_on_gpu(simulation):
         jax.config.update("jax_platform_name", "cpu")
     #
-    positions, momenta, forces, tags, H, origin, dt = backend.view(simulation)
+    positions, momenta, forces, tags, H, origin, dt = _CURRENT_BACKEND.view(simulation)
     box = Box(np.asarray(H), np.asarray(origin))
     #
     return SystemView(positions, momenta, forces, tags, box, dt)
 
 
-def _set_bias(backend, simulation):
+def _set_bias(simulation):
     # Depending on the device being used we need to use either cupy or numpy
     # (or numba) to generate a view of jax's DeviceArrays
-    if backend.is_on_gpu(simulation):
+    if _CURRENT_BACKEND.is_on_gpu(simulation):
         cupy = importlib.import_module("cupy")
         wrap = cupy.asarray
     else:
@@ -72,12 +78,16 @@ def _set_bias(backend, simulation):
     return bias
 
 
-def link(backend, simulation, sampler):
+def bind(simulation, sampler):
     """Creates a hook that couples the simulation to the sampling method."""
-    hook = backend.Hook()
-    bias = _set_bias(backend, simulation)
+    #
+    if _CURRENT_BACKEND is None:
+        raise RuntimeError("No backend has been set")
+    #
+    hook = _CURRENT_BACKEND.Hook()
+    bias = _set_bias(simulation)
     hook.initialize_from(sampler, bias)
-    backend.attach(simulation, hook)
+    _CURRENT_BACKEND.attach(simulation, hook)
     # Return the hook to ensure it doesn't get garbage collected within the scope
     # of this function (another option is to store it in a global).
     return hook


### PR DESCRIPTION
Since the backend gets assigned to a global constant within the `backends` module.