### PR TITLE
[HOOMD] Add a global pool of Sampler objects

### DIFF
--- a/pysages/backends/hoomd.py
+++ b/pysages/backends/hoomd.py
@@ -20,7 +20,7 @@ from warnings import warn
 
 # TODO: Figure out a way to automatically tie the lifetime of Sampler
 # objects to the contexts they bind to
-SAMPLERS_CONTEXTS = {}
+CONTEXTS_SAMPLERS = {}
 
 
 class ContextWrapper:
@@ -135,7 +135,7 @@ def bind(context, sampling_method, **kwargs):
     sampler = Sampler(method_bundle, sync_and_bias)
     context.integrator.cpp_integrator.setHalfStepHook(sampler)
     #
-    SAMPLERS_CONTEXTS[context] = sampler
+    CONTEXTS_SAMPLERS[context] = sampler
     #
     return sampler
 
@@ -145,7 +145,8 @@ def detach(context):
     If pysages was bound to this context, this removes the corresponding
     `Sampler` object.
     """
-    try:
-        del SAMPLERS_CONTEXTS[context]
-    except KeyError:
+    if CONTEXTS_SAMPLERS.haskey(context):
+        context.integrator.cpp_integrator.removeHalfStepHook()
+        CONTEXTS_SAMPLERS.pop(context, None)
+    else:
         warn("This context has no sampler bound to it.")

--- a/pysages/backends/hoomd.py
+++ b/pysages/backends/hoomd.py
@@ -147,6 +147,6 @@ def detach(context):
     """
     if CONTEXTS_SAMPLERS.haskey(context):
         context.integrator.cpp_integrator.removeHalfStepHook()
-        CONTEXTS_SAMPLERS.pop(context, None)
+        del CONTEXTS_SAMPLERS[context]
     else:
         warn("This context has no sampler bound to it.")


### PR DESCRIPTION
We will keep all created samplers around unless they are detached from the corresponding contexts.