### PR TITLE
Rewrite grids API

### DIFF
--- a/pysages/grids.py
+++ b/pysages/grids.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2020-2021: PySAGES contributors
+# See LICENSE.md and CONTRIBUTORS.md at https://github.com/SSAGESLabs/PySAGES
+
+from dataclasses import dataclass
+from jax import jit
+from plum import dispatch, parametric, type_parameter
+from pysages.utils import JaxArray
+
+import jax.numpy as np
+
+
+class Periodicity:
+    pass
+
+
+class Periodic(Periodicity):
+    pass
+
+
+class Aperiodic(Periodicity):
+    pass
+
+
+class ChebyshevDistributed:
+    pass
+
+
+@parametric
+@dataclass
+class Grid:
+    lower:  JaxArray
+    upper:  JaxArray
+    shape:  JaxArray
+    size:   JaxArray
+
+    @classmethod
+    def __infer_type_parameter__(cls, *args, **kwargs):
+        return Periodic if kwargs.get("periodic", False) else Aperiodic
+
+    def __init__(self, lower, upper, shape, **kwargs):
+        self.__check_init_invariants__(**kwargs)
+        self.lower = np.asarray(lower)
+        self.upper = np.asarray(upper)
+        self.shape = np.asarray(shape)
+        self.size = self.upper - self.lower
+
+    def __check_init_invariants__(self, **kwargs):
+        T = type_parameter(self)
+        if not (issubclass(type(T), type) and issubclass(T, Periodicity)):
+            raise TypeError("Type parameter must be a subclass of Periodicity.")
+        if len(kwargs) > 1 or (len(kwargs) == 1 and "periodic" not in kwargs):
+            raise ValueError("Invalid keyword argument")
+        periodic = kwargs.get("periodic", T is Periodic)
+        if type(periodic) is not bool:
+            raise TypeError("`periodic` must be a bool.")
+        if (not periodic and T is Periodic) or (periodic and T is Aperiodic):
+            raise ValueError("Type parameter and keyword `periodic` do not match")
+
+    def __repr__(self):
+        T = type_parameter(self)
+        P = "" if T is Aperiodic else f"[{T.__name__}]"
+        return f"Grid{P} ({' x '.join(map(str, self.shape))})"
+
+    @property
+    def is_periodic(self):
+        return type_parameter(self) is Periodic
+
+
+@dispatch
+def build_indexer(grid: Grid):
+    """
+    Returns a function which takes a position `x` and computes the integer
+    indices of the entry within the grid that contains `x`. If `x` lies outside
+    the grid, the indices returned correspond to `x = grid.upper`.
+    """
+    def get_index(x):
+        h = grid.size / grid.shape
+        idx = (x.flatten() - grid.lower) // h
+        idx = np.where((idx < 0) | (idx > grid.shape), grid.shape, idx)
+        return (*np.flip(np.uint32(idx)),)
+
+    return jit(get_index)
+
+
+@dispatch
+def build_indexer(grid: Grid[Periodic]):
+    """
+    Returns a function which takes a position `x` and computes the integer
+    indices of the entry within the grid that contains `x`. It `x` lies outside
+    the grid boundaries, the indices are wrapped around.
+    """
+    def get_index(x):
+        h = grid.size / grid.shape
+        idx = (x.flatten() - grid.lower) // h
+        idx = idx % grid.shape
+        return (*np.flip(np.uint32(idx)),)
+
+    return jit(get_index)
+
+
+@dispatch
+def build_indexer(grid: Grid[Aperiodic], mode: ChebyshevDistributed):
+    """
+    Returns a function which takes a position `x` and computes the integer
+    indices of the entry within the grid that contains `x`. The bins within the
+    grid are 'Chebyshev distributed' along each axis. If `x` lies outside the
+    grid, the indices returned correspond to `x = grid.upper`.
+    """
+    def get_index(x):
+        x = 2 * (grid.lower - x.flatten()) / grid.size + 1
+        idx = (grid.shape * np.arccos(x)) // np.pi
+        idx = np.nan_to_num(idx, nan = grid.shape)
+        return (*np.flip(np.uint32(idx)),)
+
+    return jit(get_index)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,0 +1,95 @@
+from jax.numpy import pi, uint32 as UInt32
+from pysages.grids import (
+    Aperiodic,
+    ChebyshevDistributed,
+    Grid,
+    Periodic,
+    build_indexer,
+)
+
+import jax.numpy as np
+import pytest
+
+
+lower_1d = (-pi,)
+upper_1d = ( pi,)
+shape_1d = (64,)
+
+lower_2d = (-pi, -1.0)
+upper_2d = ( pi,  1.0)
+shape_2d = (64, 32)
+
+
+def test_Grid_constructor():
+    lower = lower_1d
+    upper = upper_1d
+    shape = shape_1d
+
+    # Default constructor
+    grid = Grid(lower, upper, shape)
+    # Periodic grid kw constructor
+    periodic_grid = Grid(lower, upper, shape, periodic = True)
+    # Parametric constructors
+    grid_tv = Grid[Aperiodic](lower, upper, shape)
+    periodic_grid_tv = Grid[Periodic](lower, upper, shape)
+
+    assert grid == grid_tv
+    assert periodic_grid == periodic_grid_tv
+    assert grid != periodic_grid
+
+    assert ~grid.is_periodic
+    assert periodic_grid.is_periodic
+
+    # Test constructor exceptions
+    with pytest.raises(TypeError):
+        Grid(lower, upper, shape, periodic = None)
+    with pytest.raises(TypeError):
+        Grid(lower, upper, shape, periodic = 1)
+    with pytest.raises(TypeError):
+        Grid[1](lower, upper, shape)
+    with pytest.raises(TypeError):
+        Grid[bool](lower, upper, shape)
+    with pytest.raises(ValueError):
+        Grid(lower, upper, shape, invalid_keyword = True)
+    with pytest.raises(ValueError):
+        Grid[Periodic](lower, upper, shape, periodic = False)
+    with pytest.raises(ValueError):
+        Grid[Aperiodic](lower, upper, shape, periodic = True)
+
+
+def test_grid_indexing():
+    lower = lower_1d
+    upper = upper_1d
+    shape = shape_1d
+
+    grid = Grid(lower, upper, shape)
+    periodic_grid = Grid[Periodic](lower, upper, shape)
+
+    get_index = build_indexer(grid)
+    cheb_get_index = build_indexer(grid, ChebyshevDistributed())
+    periodic_get_index = build_indexer(periodic_grid)
+
+    # Indexing 1D
+    assert get_index(-pi - 1) == (UInt32(64),)
+    assert get_index(-pi) == (UInt32(0),)
+    assert get_index(0.0) == (UInt32(32),)
+    assert cheb_get_index(-pi - 1) == (UInt32(64),)
+    assert cheb_get_index(-pi) == (UInt32(0),)
+    assert cheb_get_index(-pi * 0.996) == (UInt32(1),)
+    assert cheb_get_index(0.0) == (UInt32(32),)
+    assert periodic_get_index(-pi * (1 + 0.99 / 32)) == (UInt32(63),)
+    assert periodic_get_index(-pi) == periodic_get_index(pi) == (UInt32(0),)
+    assert periodic_get_index(0.0) == (UInt32(32),)
+
+    lower = lower_2d
+    upper = upper_2d
+    shape = shape_2d
+
+    grid_2d = Grid(lower, upper, shape)
+    get_index_2d = build_indexer(grid_2d)
+
+    # Indexing 2D
+    x_lo_up = np.array([-pi, 1])
+    x_up_lo_out = np.array([pi, -2])
+    assert get_index_2d(x_lo_up) == (UInt32(32), UInt32(0))
+    assert get_index_2d(x_up_lo_out) == (UInt32(32), UInt32(64))


### PR DESCRIPTION
Do note that this is now in `pysages/grids.py` instead of `pysages/ssages/grid.py` (the `ssages` path does not serve any real purpose and I plan to eliminate it eventually).

Once this is merged, I will make another PR switching all the grids-dependent code to use the new API.