### PR TITLE
Update OpenMM to version 7.6

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -19,7 +19,7 @@ RUN git clone https://github.com/glotzerlab/hoomd-blue.git && cd hoomd-blue && g
 ENV PYTHONPATH=${PYTHONPATH}:/hoomd-install
 
 RUN apt-get update && apt-get install -y doxygen swig nvidia-cuda-dev nvidia-cuda-toolkit python3-setuptools cython3
-RUN git clone https://github.com/openmm/openmm.git &&  cd openmm &&  git checkout 7.5.0 &&  mkdir build && cd build && cmake -DPYTHON_EXECUTABLE=`which python3` -DCMAKE_INSTALL_PREFIX=../install -DBUILD_TESTING=OFF .. && make -j $(nproc) install
+RUN git clone https://github.com/openmm/openmm.git &&  cd openmm &&  git checkout 7.6.0 &&  mkdir build && cd build && cmake -DPYTHON_EXECUTABLE=`which python3` -DCMAKE_INSTALL_PREFIX=../install -DBUILD_TESTING=OFF .. && make -j $(nproc) install
 ENV OPENMM_INCLUDE_PATH=/openmm/install/include
 ENV OPENMM_LIB_PATH=/openmm/install/lib
 RUN cd openmm/build/python && python3 setup.py install


### PR DESCRIPTION
After merge, we have to manually trigger the build to update docker-hub.
(And for the plugins too.)