### PR TITLE
Make the context part of the method

### DIFF
--- a/pysages/methods/core.py
+++ b/pysages/methods/core.py
@@ -67,9 +67,9 @@ class SamplingMethod(ABC):
             `kwargs` gets passed to the backend `run` function.
         """
         context = context_generator(**context_args)
-        wrapped_context = ContextWrapper(context, self, callback)
-        with wrapped_context:
-            wrapped_context.run(timesteps, **kwargs)
+        self.context = ContextWrapper(context, self, callback)
+        with self.context:
+            self.context.run(timesteps, **kwargs)
 
 
 class GriddedSamplingMethod(SamplingMethod):

--- a/pysages/methods/umbrella_integration.py
+++ b/pysages/methods/umbrella_integration.py
@@ -94,6 +94,8 @@ class UmbrellaIntegration(HarmonicBias):
         result["nabla_A"] =  []
         result["A"] = []
 
+        self.context = []
+
         for rep in range(Nreplica):
             self.center = centers[rep]
             self.kspring = ksprings[rep]
@@ -102,6 +104,7 @@ class UmbrellaIntegration(HarmonicBias):
             context = context_generator(**context_args)
             callback = HistogramLogger(hist_periods[rep], hist_offsets[rep])
             wrapped_context = ContextWrapper(context, self, callback)
+            self.context.append(wrapped_context)
 
             with wrapped_context:
                 wrapped_context.run(timesteps[rep])


### PR DESCRIPTION
This is a stopgap solution to enable building FES for methods such as ABF, but I'm exposing the all `ContextWrapper`s generated in all of our current methods.

This is most likely to change in light of #54, but lets move on with this for now.