### PR TITLE
[CVs] Make `requires_box_unwrapping` true by default

### DIFF
--- a/pysages/collective_variables/coordinates.py
+++ b/pysages/collective_variables/coordinates.py
@@ -52,10 +52,6 @@ def weighted_barycenter(positions, weights):
 
 
 class Component(AxisCV):
-    def __init__(self, indices, axis):
-        super().__init__(indices, axis)
-        self.requires_box_unwrapping = True
-
     @property
     def function(self):
         return (lambda rs: barycenter(rs)[self.axis])

--- a/pysages/collective_variables/core.py
+++ b/pysages/collective_variables/core.py
@@ -51,7 +51,7 @@ class CollectiveVariable(ABC):
 
         self.indices = indices
         self.groups = groups
-        self.requires_box_unwrapping = False
+        self.requires_box_unwrapping = True
 
     @abstractproperty
     def function(self):


### PR DESCRIPTION
Closes #105

If a user know this is not necessary, it's easy to set it to `False` after the CV is declared but before the sampling method is built.