### PR TITLE
Update copy to match new jax behavior

### DIFF
--- a/pysages/utils.py
+++ b/pysages/utils.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 from importlib import import_module
 from typing import Union
 
+import numpy
+
 from jax import numpy as np
 from jax.tree_util import register_pytree_node
 from plum import Dispatcher
@@ -51,7 +53,7 @@ def copy(t: tuple, *args):
 
 @dispatch
 def copy(x: JaxArray):
-    return np.array(x)
+    return x.copy()
 
 
 @dispatch
@@ -61,7 +63,7 @@ def copy(x, _: ToCPU):
 
 @dispatch
 def copy(x: JaxArray, _: ToCPU):
-    return x.copy()
+    return numpy.asarray(x._value)
 
 
 def identity(x):

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ license = MIT/GPL-3.0
 [options]
 packages = find:
 python_requires = >=3.6
-install_requires = jax>=0.2.15; cython; plum-dispatch>=1.5.4; fastcore; numba
+install_requires = jax>=0.3.5; cython; plum-dispatch>=1.5.4; fastcore; numba
 
 [build_sphinx]
 all-files = 1


### PR DESCRIPTION
Also, set minimum lower bound for jax to 0.3.5 to make sure new installations work properly.