### PR TITLE
Implement analyze for ABF

### DIFF
--- a/docs/source/pysages_wordlist.txt
+++ b/docs/source/pysages_wordlist.txt
@@ -34,3 +34,4 @@ alanine
 dipeptide
 conformational
 kT
+Sobolev

--- a/examples/openmm/abf/alanine-dipeptide_openmm.py
+++ b/examples/openmm/abf/alanine-dipeptide_openmm.py
@@ -5,7 +5,7 @@
 from pysages.colvars import DihedralAngle
 from pysages.methods import ABF
 from pysages.utils import try_import
-
+import matplotlib.pyplot as plt
 import numpy
 import pysages
 
@@ -56,12 +56,67 @@ def generate_simulation(pdb_filename=adp_pdb, T=T, dt=dt):
 
 
 # %%
+# helping function for plotting results
+def plot_energy(result):
+    surface = numpy.asarray(result["free_energy"])
+    fig, ax = plt.subplots()
+    im = ax.imshow(
+        surface, interpolation="bicubic", origin="lower", extent=[-pi, pi, -pi, pi], aspect=1
+    )
+    ax.contour(surface, levels=15, linewidths=0.75, colors="k", extent=[-pi, pi, -pi, pi])
+    plt.colorbar(im)
+    fig.savefig("energy.pdf")
+
+
+# %%
+# %%
+def plot_histogram(result):
+    surface = numpy.asarray(result["histogram"]) / numpy.nanmax(numpy.asarray(result["histogram"]))
+    fig, ax = plt.subplots()
+    im = ax.imshow(
+        surface, interpolation="bicubic", origin="lower", extent=[-pi, pi, -pi, pi], aspect=1
+    )
+    ax.contour(surface, levels=15, linewidths=0.75, colors="k", extent=[-pi, pi, -pi, pi])
+    plt.colorbar(im)
+    fig.savefig("histogram.pdf")
+
+
+# %%
+# %%
+def plot_forces(result):
+    fig, ax = plt.subplots()
+
+    ax.set_xlabel("CV")
+    ax.set_ylabel("Forces $[\\epsilon]$")
+
+    forces = numpy.asarray(result["mean_force"])
+    x = numpy.asarray(result["mesh"])
+    plt.quiver(x, forces, width=(0.0002 * (x[x.shape[0] - 1, 0] - x[0, 0])), headwidth=3)
+
+    fig.savefig("forces.pdf")
+
+
+# Stores forces and free energies for post-analysis
+def save_energy_forces(result):
+    energy = numpy.asarray(result["free_energy"])
+    forces = numpy.asarray(result["mean_force"])
+    grid = numpy.asarray(result["mesh"])
+    numpy.savetxt("FES.csv", numpy.hstack([grid, energy.reshape(-1, 1)]))
+    numpy.savetxt("Forces.csv", numpy.hstack([grid, forces.reshape(-1, grid.shape[1])]))
+
+
+# %%
 def main():
     cvs = [DihedralAngle((4, 6, 8, 14)), DihedralAngle((6, 8, 14, 16))]
     grid = pysages.Grid(lower=(-pi, -pi), upper=(pi, pi), shape=(32, 32), periodic=True)
     method = ABF(cvs, grid)
 
-    pysages.run(method, generate_simulation, 25)
+    raw_result = pysages.run(method, generate_simulation, 25)
+    result = pysages.analyze(raw_result, topology=(14,))
+
+    plot_energy(result)
+    plot_histogram(result)
+    save_energy_forces(result)
 
 
 # %%

--- a/pysages/methods/abf.py
+++ b/pysages/methods/abf.py
@@ -17,15 +17,22 @@ derivative of the product :math:`W\\cdot p` (equation 9 of reference) is approxi
 second order backward finite difference in the simulation time step.
 """
 
+from functools import partial
 from typing import NamedTuple
 
-from jax import jit, numpy as np
+from jax import jit, numpy as np, vmap
 from jax.lax import cond
 from jax.scipy import linalg
 
+from pysages.approxfun.core import compute_mesh, scale as _scale
 from pysages.grids import build_indexer
-from pysages.methods.core import GriddedSamplingMethod, generalize
+from pysages.methods.core import GriddedSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
+from pysages.ml.models import MLP
+from pysages.ml.objectives import GradientsSSE, L2Regularization
+from pysages.ml.optimizers import LevenbergMarquardt
+from pysages.ml.training import NNData, build_fitting_function, convolve
+from pysages.ml.utils import blackman_kernel, pack, unpack
 from pysages.utils import JaxArray, dispatch
 
 
@@ -36,11 +43,11 @@ class ABFState(NamedTuple):
     Parameters
     ----------
 
-    bias: JaxArray (Nparticles, 3)
-        Array with biasing forces for each particle.
-
     xi: JaxArray (CV shape)
         Last collective variable recorded in the simulation.
+
+    bias: JaxArray (Nparticles, 3)
+        Array with biasing forces for each particle.
 
     hist: JaxArray (grid.shape)
         Histogram of visits to the bins in the collective variable grid.
@@ -58,8 +65,8 @@ class ABFState(NamedTuple):
         Product of W matrix and momenta matrix for the previous step.
     """
 
-    bias: JaxArray
     xi: JaxArray
+    bias: JaxArray
     hist: JaxArray
     Fsum: JaxArray
     force: JaxArray
@@ -165,13 +172,14 @@ def _abf(method, snapshot, helpers):
         ABFState
             Initialized State
         """
+        xi, _ = cv(helpers.query(snapshot))
         bias = np.zeros((natoms, 3))
         hist = np.zeros(grid.shape, dtype=np.uint32)
         Fsum = np.zeros((*grid.shape, dims))
         force = np.zeros(dims)
         Wp = np.zeros(dims)
         Wp_ = np.zeros(dims)
-        return ABFState(bias, None, hist, Fsum, force, Wp, Wp_)
+        return ABFState(xi, bias, hist, Fsum, force, Wp, Wp_)
 
     def update(state, data):
         """
@@ -210,7 +218,7 @@ def _abf(method, snapshot, helpers):
         force = estimate_force(xi, I_xi, Fsum, hist).reshape(dims)
         bias = np.reshape(-Jxi.T @ force, state.bias.shape)
 
-        return ABFState(bias, xi, hist, Fsum, force, Wp, state.Wp)
+        return ABFState(xi, bias, hist, Fsum, force, Wp, state.Wp)
 
     return snapshot, initialize, generalize(update, helpers)
 
@@ -244,3 +252,92 @@ def build_force_estimator(method: ABF):
             return cond(ob, restraints_force, average_force, data)
 
     return estimate_force
+
+
+@dispatch
+def analyze(result: Result[ABF], **kwargs):
+    """
+    Computes the free energy from the result of an `ABF` run.
+    Integrates the forces using Sobolev approximation of functions by gradient learning.
+
+    Parameters
+    ----------
+
+    result: Result[ABF]:
+        Result bundle containing method, final ABF state, and callback.
+
+    topology: Optional[Tuple[int]] = (4, 4)
+        Defines the architecture of the neural network (number of nodes of each hidden layer).
+
+    Returns
+    -------
+
+    dict: A dictionary with the following keys:
+
+        histogram: JaxArray
+            Histogram for the states visited during the method.
+
+        mean_force: JaxArray
+            Average force at each bin of the CV grid.
+
+        free_energy: JaxArray
+            Free Energy at each bin of the CV grid.
+
+        mesh: JaxArray
+            Grid used in the method.
+
+        fes_fn: Callable[[JaxArray], JaxArray]
+            Function that allows to interpolate the free energy in the CV domain defined
+            by the grid.
+    """
+    topology = kwargs.get("topology", (4, 4))
+    method = result.method
+    state = result.states[0]
+    grid = method.grid
+    inputs = (compute_mesh(grid) + 1) * grid.size / 2 + grid.lower
+
+    model = MLP(grid.shape.size, 1, topology, transform=partial(_scale, grid=grid))
+    optimizer = LevenbergMarquardt(loss=GradientsSSE(), max_iters=2500, reg=L2Regularization(1e-3))
+    fit = build_fitting_function(model, optimizer)
+
+    @vmap
+    def smooth(data):
+        boundary = "wrap" if grid.is_periodic else "edge"
+        kernel = np.float32(blackman_kernel(grid.shape.size, 7))
+        return convolve(data.T, kernel, boundary=boundary).T
+
+    def train(nn, data):
+        axes = tuple(range(data.ndim - 1))
+        std = data.std(axis=axes).max()
+        reference = np.float64(smooth(np.float32(data / std)))
+        params = fit(nn.params, inputs, reference).params
+        return NNData(params, nn.mean, std / reference.std(axis=axes).max())
+
+    def build_fes_fn(state):
+        hist = np.expand_dims(state.hist, state.hist.ndim)
+        F = state.Fsum / np.maximum(hist, 1)
+
+        ps, layout = unpack(model.parameters)
+        nn = train(NNData(ps, 0.0, 1.0), F)
+
+        def fes_fn(x):
+            params = pack(nn.params, layout)
+            A = nn.std * model.apply(params, x) + nn.mean
+            return A.max() - A
+
+        return jit(fes_fn)
+
+    def average_forces(state):
+        Fsum = state.Fsum
+        shape = (*Fsum.shape[:-1], 1)
+        return Fsum / np.maximum(state.hist.reshape(shape), 1)
+
+    fes_fn = build_fes_fn(state)
+
+    return dict(
+        histogram=state.hist,
+        mean_force=average_forces(state),
+        free_energy=fes_fn(inputs).reshape(grid.shape),
+        mesh=inputs,
+        fes_fn=fes_fn,
+    )

--- a/pysages/ml/objectives.py
+++ b/pysages/ml/objectives.py
@@ -4,8 +4,7 @@
 
 from typing import NamedTuple, Union
 
-from jax import value_and_grad, vmap
-
+from jax import grad, value_and_grad, vmap
 from pysages.ml.utils import (
     dispatch,
     number_of_weights,


### PR DESCRIPTION
Adding analyze for ABF, the function calculate the free energy from ABF simulation. It uses Sobolev approximation of functions by gradient learning, it requires a tuple with the topology for the net. The openmm example is updated accordingly.