### PR TITLE
Update jax installation instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN python -m pip install --upgrade pip
 RUN python -m pip install gsd matplotlib "pyparsing<3"
 
 # Install JAX
-RUN python -m pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
+RUN python -m pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 COPY . PySAGES
 RUN cd PySAGES && pip install .

--- a/examples/hoomd-blue/Butane_ANN.ipynb
+++ b/examples/hoomd-blue/Butane_ANN.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "pip install -q --upgrade pip\n",
     "# Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.\n",
-    "pip install -q --upgrade \"jax[cuda]\" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null"
+    "pip install -q --upgrade \"jax[cuda]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
    ]
   },
   {

--- a/examples/hoomd-blue/Butane_ANN.md
+++ b/examples/hoomd-blue/Butane_ANN.md
@@ -63,7 +63,7 @@ First, we install the jaxlib version that matches the CUDA installation of this 
 
 pip install -q --upgrade pip
 # Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.
-pip install -q --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null
+pip install -q --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null
 ```
 
 <!-- #region id="wAtjM-IroYX8" -->

--- a/examples/hoomd-blue/Butane_FUNN.ipynb
+++ b/examples/hoomd-blue/Butane_FUNN.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "pip install -q --upgrade pip\n",
     "# Installs the wheel compatible with CUDA 11 and cuDNN 8.0.5.\n",
-    "pip install -q --upgrade \"jax[cuda11_cudnn805]\" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null"
+    "pip install -q --upgrade \"jax[cuda11_cudnn805]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
    ]
   },
   {

--- a/examples/hoomd-blue/Butane_FUNN.md
+++ b/examples/hoomd-blue/Butane_FUNN.md
@@ -63,7 +63,7 @@ First, we install the jaxlib version that matches the CUDA installation of this 
 
 pip install -q --upgrade pip
 # Installs the wheel compatible with CUDA 11 and cuDNN 8.0.5.
-pip install -q --upgrade "jax[cuda11_cudnn805]" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null
+pip install -q --upgrade "jax[cuda11_cudnn805]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null
 ```
 
 <!-- #region id="wAtjM-IroYX8" -->

--- a/examples/hoomd-blue/Harmonic_Bias.ipynb
+++ b/examples/hoomd-blue/Harmonic_Bias.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "pip install -q --upgrade pip &> /dev/null\n",
     "# Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.\n",
-    "pip install -q --upgrade \"jax[cuda]\" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null"
+    "pip install -q --upgrade \"jax[cuda]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
    ]
   },
   {

--- a/examples/hoomd-blue/Harmonic_Bias.md
+++ b/examples/hoomd-blue/Harmonic_Bias.md
@@ -61,7 +61,7 @@ First, we install the jaxlib version that matches the CUDA installation of this 
 
 pip install -q --upgrade pip &> /dev/null
 # Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.
-pip install -q --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null
+pip install -q --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null
 ```
 
 <!-- #region id="mx0IRythaTyG" -->

--- a/examples/hoomd-blue/Umbrella_Integration.ipynb
+++ b/examples/hoomd-blue/Umbrella_Integration.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "pip install -q --upgrade pip &> /dev/null\n",
     "# Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.\n",
-    "pip install -q --upgrade \"jax[cuda]\" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null"
+    "pip install -q --upgrade \"jax[cuda]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
    ]
   },
   {

--- a/examples/hoomd-blue/Umbrella_Integration.md
+++ b/examples/hoomd-blue/Umbrella_Integration.md
@@ -60,7 +60,7 @@ First, we install the jaxlib version that matches the CUDA installation of this 
 
 pip install -q --upgrade pip &> /dev/null
 # Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.
-pip install -q --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null
+pip install -q --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null
 ```
 
 <!-- #region id="mx0IRythaTyG" -->

--- a/examples/openmm/Harmonic_Bias.ipynb
+++ b/examples/openmm/Harmonic_Bias.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "pip install -q --upgrade pip\n",
     "# Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.\n",
-    "pip install -q --upgrade \"jax[cuda]\" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null"
+    "pip install -q --upgrade \"jax[cuda]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
    ]
   },
   {

--- a/examples/openmm/Harmonic_Bias.md
+++ b/examples/openmm/Harmonic_Bias.md
@@ -57,7 +57,7 @@ First, we install the jaxlib version that matches the CUDA installation of this 
 
 pip install -q --upgrade pip
 # Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.
-pip install -q --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null
+pip install -q --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null
 ```
 
 <!-- #region id="mx0IRythaTyG" -->

--- a/examples/openmm/metad/Metadynamics-ADP.ipynb
+++ b/examples/openmm/metad/Metadynamics-ADP.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "pip install -q --upgrade pip\n",
     "# Installs the wheel compatible with CUDA 11 and cuDNN 8.0.5.\n",
-    "pip install -q --upgrade \"jax[cuda11_cudnn805]\" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null"
+    "pip install -q --upgrade \"jax[cuda11_cudnn805]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
    ]
   },
   {

--- a/examples/openmm/metad/Metadynamics-ADP.md
+++ b/examples/openmm/metad/Metadynamics-ADP.md
@@ -63,7 +63,7 @@ First, we install the jaxlib version that matches the CUDA installation of this 
 
 pip install -q --upgrade pip
 # Installs the wheel compatible with CUDA 11 and cuDNN 8.0.5.
-pip install -q --upgrade "jax[cuda11_cudnn805]" -f https://storage.googleapis.com/jax-releases/jax_releases.html &> /dev/null
+pip install -q --upgrade "jax[cuda11_cudnn805]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null
 ```
 
 <!-- #region id="wAtjM-IroYX8" -->


### PR DESCRIPTION
The URL for installing jax recently changed. Updating it at all the relevant places here,