### PR TITLE
Fix empty grid construction in Metadynamics

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -68,6 +68,21 @@ jobs:
         run: |
           docker load --input /tmp/pysages.tar
           docker run -t pysages bash -c "cd PySAGES/examples/openmm/abf/ && python3 ./alanine-dipeptide_openmm.py"
+  metad-alanine-dipeptide-openmm:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: pysages
+          path: /tmp
+      - name: Load and run test
+        run: |
+          docker load --input /tmp/pysages.tar
+          docker run -t pysages bash -c "cd PySAGES/examples/openmm/metad/ && python3 ./alanine-dipeptide.py --time-steps=25"
 
   metad-hoomd:
     runs-on: ubuntu-latest

--- a/examples/openmm/metad/alanine-dipeptide.py
+++ b/examples/openmm/metad/alanine-dipeptide.py
@@ -105,7 +105,7 @@ def main(argv=[]):
     deltaT = 5000 if args.well_tempered else None
     stride = 500  # frequency for depositing gaussians
     timesteps = args.time_steps
-    ngauss = timesteps // stride  # total number of gaussians
+    ngauss = timesteps // stride + 1  # total number of gaussians
 
     # Grid for storing bias potential and its gradient
     grid = pysages.Grid(lower=(-pi, -pi), upper=(pi, pi), shape=(50, 50), periodic=True)

--- a/examples/openmm/metad/alanine-dipeptide.py
+++ b/examples/openmm/metad/alanine-dipeptide.py
@@ -164,5 +164,4 @@ def main(argv=[]):
 
 # %%
 if __name__ == "__main__":
-
     main(sys.argv[1:])

--- a/pysages/grids.py
+++ b/pysages/grids.py
@@ -26,10 +26,6 @@ class Chebyshev(GridType):
     pass
 
 
-class NoGrid:
-    pass
-
-
 @parametric
 @dataclass
 class Grid:
@@ -82,7 +78,7 @@ def build_grid(T, lower, upper, shape):
 
 
 @dispatch
-def build_grid(grid: NoGrid):
+def build_grid(grid: type(None)):  # noqa: F811 # pylint: disable=C0116,E0102
     return grid
 
 
@@ -105,7 +101,7 @@ def get_info(grid: Grid):
 
 
 @dispatch
-def get_info(grid: NoGrid):
+def get_info(grid: type(None)):  # noqa: F811 # pylint: disable=C0116,E0102
     return (grid,)
 
 
@@ -127,7 +123,7 @@ def build_indexer(grid: Grid):
 
 
 @dispatch
-def build_indexer(grid: Grid[Periodic]):
+def build_indexer(grid: Grid[Periodic]):  # noqa: F811 # pylint: disable=C0116,E0102
     """
     Returns a function which takes a position `x` and computes the integer
     indices of the entry within the grid that contains `x`. It `x` lies outside
@@ -144,7 +140,7 @@ def build_indexer(grid: Grid[Periodic]):
 
 
 @dispatch
-def build_indexer(grid: Grid[Chebyshev]):
+def build_indexer(grid: Grid[Chebyshev]):  # noqa: F811 # pylint: disable=C0116,E0102
     """
     Returns a function which takes a position `x` and computes the integer
     indices of the entry within the grid that contains `x`. The bins within the

--- a/pysages/methods/core.py
+++ b/pysages/methods/core.py
@@ -12,7 +12,7 @@ from jax import grad, jit
 from plum import parametric
 
 from pysages.backends import ContextWrapper
-from pysages.grids import Grid, NoGrid, build_grid, get_info
+from pysages.grids import Grid, build_grid, get_info
 from pysages.colvars.core import build
 from pysages.utils import dispatch, identity
 
@@ -120,8 +120,9 @@ def run(
     """
     Base implementation for running a single simulation with the specified `SamplingMethod`.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
+
     method: SamplingMethod
 
     context_generator: Callable
@@ -187,7 +188,7 @@ def check_dims(cvs, grid: Grid):
 
 
 @dispatch
-def check_dims(cvs, grid: NoGrid):
+def check_dims(cvs, grid: type(None)):  # noqa: F811 # pylint: disable=C0116,E0102
     pass
 
 


### PR DESCRIPTION
Revert to use `None` as fallback for grids in Metadynamics.

Fixes #151.