### PR TITLE
indent futures to ensure they finish before collecting results.

### DIFF
--- a/pysages/methods/core.py
+++ b/pysages/methods/core.py
@@ -180,9 +180,9 @@ def run(
 
     with config.executor as ex:
         futures = [submit_work(ex, method, callback) for _ in range(config.copies)]
-        results = [future.result() for future in futures]
-        states = [r.states for r in results]
-        callbacks = None if callback is None else [r.callbacks for r in results]
+    results = [future.result() for future in futures]
+    states = [r.states for r in results]
+    callbacks = None if callback is None else [r.callbacks for r in results]
 
     return Result(method, states, callbacks)
 

--- a/pysages/methods/umbrella_integration.py
+++ b/pysages/methods/umbrella_integration.py
@@ -135,9 +135,9 @@ def run(  # pylint: disable=arguments-differ
             local_context_args["replica_num"] = rep
             callback = method.histograms[rep]
             futures.append(submit_work(ex, submethod, local_context_args, callback))
-        results = [future.result() for future in futures]
-        states = [r.states for r in results]
-        callbacks = [r.callbacks for r in results]
+    results = [future.result() for future in futures]
+    states = [r.states for r in results]
+    callbacks = [r.callbacks for r in results]
 
     return Result(method, states, callbacks)
 


### PR DESCRIPTION
This completes #161. See some of the discussion also there.

We want to ensure that all futures have finished computation before collecting the results.