### PR TITLE
Make Distance a "COG Distance" (handles also groups of points)

### DIFF
--- a/docs/source/pysages_wordlist.txt
+++ b/docs/source/pysages_wordlist.txt
@@ -18,6 +18,7 @@ kwargs
 dihedral
 Anisotropy
 barycenter
+barycenters
 centroid
 anisotropy
 convolving

--- a/pysages/colvars/coordinates.py
+++ b/pysages/colvars/coordinates.py
@@ -90,7 +90,7 @@ class Distance(TwoPointCV):
 def distance(p1, p2):
     """
     Returns the distance between two points in space or
-    between the barycenter of two groups of points in space.
+    between the barycenters of two groups of points in space.
 
     Parameters
     ----------

--- a/pysages/colvars/coordinates.py
+++ b/pysages/colvars/coordinates.py
@@ -89,7 +89,7 @@ class Distance(TwoPointCV):
 
 def distance(p1, p2):
     """
-    Returns the distance between two points in space or 
+    Returns the distance between two points in space or
     between the barycenter of two groups of points in space.
 
     Parameters
@@ -104,7 +104,7 @@ def distance(p1, p2):
     distance : float
         Distance between the two points.
     """
-    r1  = barycenter(p1)
-    r2  = barycenter(p2)
+    r1 = barycenter(p1)
+    r2 = barycenter(p2)
 
     return linalg.norm(r1 - r2)

--- a/pysages/colvars/coordinates.py
+++ b/pysages/colvars/coordinates.py
@@ -89,18 +89,22 @@ class Distance(TwoPointCV):
 
 def distance(p1, p2):
     """
-    Returns the distance between two points in space.
+    Returns the distance between two points in space or 
+    between the barycenter of two groups of points in space.
 
     Parameters
     ----------
     p1 : DeviceArray
-        Array containing the position in space of the first point.
+        Array containing the position in space of the first point or group of points.
     p2 : DeviceArray
-        Array containing the position in space of the second point.
+        Array containing the position in space of the second point or group of points.
 
     Returns
     -------
     distance : float
         Distance between the two points.
     """
-    return linalg.norm(p1 - p2)
+    r1  = barycenter(p1)
+    r2  = barycenter(p2)
+
+    return linalg.norm(r1 - r2)


### PR DESCRIPTION
Something we discussed with @pabloferz and found that it may make for a more intuitive and flexible behavior for `Distance`.

Basically, we make the `Distance` CV a "barycenter distance" so that it can handle both distances between single points but also between group of points (by computing the distance between the barycenter aka center_of_geometry of the groups of atoms).