### PR TITLE
Enable meaningful post action triggers for OpenMM

### DIFF
--- a/examples/openmm/abf/alanine-dipeptide_openmm.py
+++ b/examples/openmm/abf/alanine-dipeptide_openmm.py
@@ -105,13 +105,16 @@ def save_energy_forces(result):
     numpy.savetxt("Forces.csv", numpy.hstack([grid, forces.reshape(-1, grid.shape[1])]))
 
 
+def post_run_action(**kwargs):
+    kwargs.get("context").saveState("final.xml")
+
 # %%
 def main():
     cvs = [DihedralAngle((4, 6, 8, 14)), DihedralAngle((6, 8, 14, 16))]
     grid = pysages.Grid(lower=(-pi, -pi), upper=(pi, pi), shape=(32, 32), periodic=True)
     method = ABF(cvs, grid)
 
-    raw_result = pysages.run(method, generate_simulation, 25)
+    raw_result = pysages.run(method, generate_simulation, 25, post_run_action=post_run_action)
     result = pysages.analyze(raw_result, topology=(14,))
 
     plot_energy(result)

--- a/examples/openmm/abf/alanine-dipeptide_openmm.py
+++ b/examples/openmm/abf/alanine-dipeptide_openmm.py
@@ -108,6 +108,7 @@ def save_energy_forces(result):
 def post_run_action(**kwargs):
     kwargs.get("context").saveState("final.xml")
 
+
 # %%
 def main():
     cvs = [DihedralAngle((4, 6, 8, 14)), DihedralAngle((6, 8, 14, 16))]

--- a/examples/openmm/umbrella_integration/integration.py
+++ b/examples/openmm/umbrella_integration/integration.py
@@ -69,6 +69,10 @@ def get_executor(args):
     return SerialExecutor()
 
 
+def post_run_action(**kwargs):
+    kwargs.get("context").saveState(f"final_{kwargs.get('replica_num')}.xml")
+
+
 def main(argv):
     args = get_args(argv)
 
@@ -83,6 +87,7 @@ def main(argv):
         generate_simulation,
         args.time_steps,
         executor=get_executor(args),
+        post_run_action=post_run_action,
     )
     result = pysages.analyze(raw_result)
     print(result)

--- a/pysages/methods/core.py
+++ b/pysages/methods/core.py
@@ -241,6 +241,7 @@ def run(  # noqa: F811 # pylint: disable=C0116,E0102
     timesteps = int(timesteps)
 
     context = context_generator(**context_args)
+    context_args["context"] = context
     wrapped_context = ContextWrapper(context, method, callback)
     with wrapped_context:
         wrapped_context.run(timesteps, **kwargs)

--- a/pysages/methods/ffs.py
+++ b/pysages/methods/ffs.py
@@ -134,6 +134,7 @@ def run(
     context_args = {} if context_args is None else context_args
 
     context = context_generator(**context_args)
+    context_args["context"] = context
     wrapped_context = ContextWrapper(context, method, callback)
 
     with wrapped_context:


### PR DESCRIPTION
Store the generated context into `context_args`.

This allows direct access to the simulation context in the `post_run_actions` to write final simulation files with OpenMM.
Hoomd-blue doesn't need it, since you can automatically operate on the currently activated context, but OpenMM seems to require direct access to the `simulation` object.

With the PR the following is possible for OpenMM.

```python
def post_run_action(**kwargs):
  kwargs.get("context").saveState("final.xml")
```

The equivalent for hoomd-blue is:
```python
def post_run_action(**kwargs):
      hoomd.dump.gsd(filename="final.gsd", overwrite=True, period=None, group=hoomd.group.all())
```
And it doesn't need direct access to the simulation context.

This makes restarting and keeping a checkpoint at the end possible.
