### PR TITLE
Small fix in butane ANN example ipynb/md files

### DIFF
--- a/examples/hoomd-blue/ann/Butane_ANN.ipynb
+++ b/examples/hoomd-blue/ann/Butane_ANN.ipynb
@@ -654,7 +654,7 @@
     }
    ],
    "source": [
-    "result = pysages.run(method, generate_context, int(5e5))"
+    "run_result = pysages.run(method, generate_context, int(5e5))"
    ]
   },
   {

--- a/examples/hoomd-blue/ann/Butane_ANN.md
+++ b/examples/hoomd-blue/ann/Butane_ANN.md
@@ -352,7 +352,7 @@ Make sure to run with GPU support, otherwise, it can take a very long time.
 <!-- #endregion -->
 
 ```python colab={"base_uri": "https://localhost:8080/"} id="K951m4BbpUar" outputId="f01ca7e3-69f4-4218-9eb5-cdc022f877b8"
-result = pysages.run(method, generate_context, int(5e5))
+run_result = pysages.run(method, generate_context, int(5e5))
 ```
 
 <!-- #region id="PXBKUfK0p9T2" -->


### PR DESCRIPTION
Small (but still important, as it breaks the example) typo in the butane ANN example. 
[jupytext](https://github.com/mwouts/jupytext) is quite neat :)