### PR TITLE
Update Butane-FUNN notebook to use the analyze function

### DIFF
--- a/examples/hoomd-blue/funn/Butane_FUNN.ipynb
+++ b/examples/hoomd-blue/funn/Butane_FUNN.ipynb
@@ -1,798 +1,794 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "T-Qkg9C9n7Cc"
-   },
-   "source": [
-    "\n",
-    "# Setting up the environment\n",
-    "\n",
-    "First, we are setting up our environment. We use an already compiled and packaged installation of HOOMD-blue and the DLExt plugin.\n",
-    "We copy it from Google Drive and install PySAGES for it.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "id": "3eTbKklCnyd_"
-   },
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "\n",
-    "BASE_URL=\"https://drive.google.com/u/0/uc?id=1hsKkKtdxZTVfHKgqVF6qV2e-4SShmhr7&export=download\"\n",
-    "wget -q --load-cookies /tmp/cookies.txt \"$BASE_URL&confirm=$(wget -q --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate $BASE_URL -O- | sed -rn 's/.*confirm=(\\w+).*/\\1\\n/p')\" -O pysages-env.zip\n",
-    "rm -rf /tmp/cookies.txt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "KRPmkpd9n_NG",
-    "outputId": "2c72bbc3-0731-4d62-98e1-d48f8254adcb"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "env: PYSAGES_ENV=/env/pysages\n"
-     ]
-    }
-   ],
-   "source": [
-    "%env PYSAGES_ENV=/env/pysages"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "J7OY5K9VoBBh"
-   },
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "\n",
-    "mkdir -p $PYSAGES_ENV .\n",
-    "unzip -qquo pysages-env.zip -d $PYSAGES_ENV"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "id": "LlVSU_-FoD4w"
-   },
-   "outputs": [],
-   "source": [
-    "!update-alternatives --auto libcudnn &> /dev/null"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "id": "EMAWp8VloIk4"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "ver = sys.version_info\n",
-    "sys.path.append(os.environ[\"PYSAGES_ENV\"] + \"/lib/python\" + str(ver.major) + \".\" + str(ver.minor) + \"/site-packages/\")\n",
-    "\n",
-    "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_strict_conv_algorithm_picker=false\"\n",
-    "os.environ[\"LD_LIBRARY_PATH\"] = \"/usr/lib/x86_64-linux-gnu:\" + os.environ[\"LD_LIBRARY_PATH\"]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "we_mTkFioS6R"
-   },
-   "source": [
-    "\n",
-    "## PySAGES\n",
-    "\n",
-    "The next step is to install PySAGES.\n",
-    "First, we install the jaxlib version that matches the CUDA installation of this Colab setup. See the JAX documentation [here](https://github.com/google/jax) for more details.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "id": "vK0RZtbroQWe"
-   },
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "\n",
-    "pip install -q --upgrade pip\n",
-    "# Installs the wheel compatible with CUDA 11 and cuDNN 8.0.5.\n",
-    "pip install -q --upgrade \"jax[cuda11_cudnn805]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "wAtjM-IroYX8"
-   },
-   "source": [
-    "\n",
-    "Now we can finally install PySAGES. We clone the newest version from [here](https://github.com/SSAGESLabs/PySAGES) and build the remaining pure python dependencies and PySAGES itself.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "id": "B-HB9CzioV5j"
-   },
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "\n",
-    "rm -rf PySAGES\n",
-    "git clone https://github.com/SSAGESLabs/PySAGES.git &> /dev/null\n",
-    "cd PySAGES\n",
-    "pip install -q . &> /dev/null"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "id": "ppTzMmyyobHB"
-   },
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "\n",
-    "mkdir /content/funn\n",
-    "cd /content/funn"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "KBFVcG1FoeMq"
-   },
-   "source": [
-    "\n",
-    "# FUNN-biased simulations\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "0W2ukJuuojAl"
-   },
-   "source": [
-    "\n",
-    "FUNN gradually learns the free energy gradient from a discrete estimate based on the same algorithm as the ABF method, but employs a neural network to provide a continuous approximation to it.\n",
-    "\n",
-    "For this Colab, we are using butane as the example molecule.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "id": "BBvC7Spoog82"
-   },
-   "outputs": [],
-   "source": [
-    "import hoomd\n",
-    "import hoomd.md\n",
-    "\n",
-    "import numpy\n",
-    "\n",
-    "\n",
-    "pi = numpy.pi\n",
-    "kT = 0.596161\n",
-    "dt = 0.02045\n",
-    "mode = \"--mode=gpu\"\n",
-    "\n",
-    "\n",
-    "def generate_context(kT = kT, dt = dt, mode = mode):\n",
-    "    \"\"\"\n",
-    "    Generates a simulation context, we pass this function to the attribute\n",
-    "    `run` of our sampling method.\n",
-    "    \"\"\"\n",
-    "    hoomd.context.initialize(mode)\n",
-    "\n",
-    "    ### System Definition\n",
-    "    snapshot = hoomd.data.make_snapshot(\n",
-    "        N = 14,\n",
-    "        box = hoomd.data.boxdim(Lx = 41, Ly = 41, Lz = 41),\n",
-    "        particle_types = ['C', 'H'],\n",
-    "        bond_types = [\"CC\", \"CH\"],\n",
-    "        angle_types = [\"CCC\", \"CCH\", \"HCH\"],\n",
-    "        dihedral_types = [\"CCCC\", \"HCCC\", \"HCCH\"],\n",
-    "        pair_types = [\"CCCC\", \"HCCC\", \"HCCH\"],\n",
-    "        dtype = \"double\"\n",
-    "    )\n",
-    "\n",
-    "    snapshot.particles.typeid[0] = 0\n",
-    "    snapshot.particles.typeid[1:4] = 1\n",
-    "    snapshot.particles.typeid[4] = 0\n",
-    "    snapshot.particles.typeid[5:7] = 1\n",
-    "    snapshot.particles.typeid[7] = 0\n",
-    "    snapshot.particles.typeid[8:10] = 1\n",
-    "    snapshot.particles.typeid[10] = 0\n",
-    "    snapshot.particles.typeid[11:14] = 1\n",
-    "\n",
-    "    positions = numpy.array([\n",
-    "        [-2.990196,  0.097881,  0.000091],\n",
-    "        [-2.634894, -0.911406,  0.001002],\n",
-    "        [-2.632173,  0.601251, -0.873601],\n",
-    "        [-4.060195,  0.099327, -0.000736],\n",
-    "        [-2.476854,  0.823942,  1.257436],\n",
-    "        [-2.832157,  1.833228,  1.256526],\n",
-    "        [-2.834877,  0.320572,  2.131128],\n",
-    "        [-0.936856,  0.821861,  1.258628],\n",
-    "        [-0.578833,  1.325231,  0.384935],\n",
-    "        [-0.581553, -0.187426,  1.259538],\n",
-    "        [-0.423514,  1.547922,  2.515972],\n",
-    "        [-0.781537,  1.044552,  3.389664],\n",
-    "        [ 0.646485,  1.546476,  2.516800],\n",
-    "        [-0.778816,  2.557208,  2.515062]\n",
-    "    ])\n",
-    "\n",
-    "    reference_box_low_coords = numpy.array([-22.206855, -19.677099, -19.241968])\n",
-    "    box_low_coords = numpy.array([\n",
-    "        -snapshot.box.Lx / 2,\n",
-    "        -snapshot.box.Ly / 2,\n",
-    "        -snapshot.box.Lz / 2\n",
-    "    ])\n",
-    "    positions += (box_low_coords - reference_box_low_coords)\n",
-    "\n",
-    "    snapshot.particles.position[:] = positions[:]\n",
-    "\n",
-    "    mC = 12.00\n",
-    "    mH = 1.008\n",
-    "    snapshot.particles.mass[:] = [\n",
-    "        mC, mH, mH, mH,\n",
-    "        mC, mH, mH,\n",
-    "        mC, mH, mH,\n",
-    "        mC, mH, mH, mH\n",
-    "    ]\n",
-    "\n",
-    "    reference_charges = numpy.array([\n",
-    "        -0.180000, 0.060000, 0.060000, 0.060000,\n",
-    "        -0.120000, 0.060000, 0.060000,\n",
-    "        -0.120000, 0.060000, 0.060000,\n",
-    "        -0.180000, 0.060000, 0.060000, 0.060000]\n",
-    "    )\n",
-    "    charge_conversion = 18.22262\n",
-    "    snapshot.particles.charge[:] = charge_conversion * reference_charges[:]\n",
-    "\n",
-    "    snapshot.bonds.resize(13)\n",
-    "    snapshot.bonds.typeid[0:3] = 1\n",
-    "    snapshot.bonds.typeid[3] = 0\n",
-    "    snapshot.bonds.typeid[4:6] = 1\n",
-    "    snapshot.bonds.typeid[6] = 0\n",
-    "    snapshot.bonds.typeid[7:9] = 1\n",
-    "    snapshot.bonds.typeid[9] = 0\n",
-    "    snapshot.bonds.typeid[10:13] = 1\n",
-    "\n",
-    "    snapshot.bonds.group[:] = [\n",
-    "        [0, 2], [0, 1], [0, 3], [0, 4],\n",
-    "        [4, 5], [4, 6], [4, 7],\n",
-    "        [7, 8], [7, 9], [7, 10],\n",
-    "        [10, 11], [10, 12], [10, 13]\n",
-    "    ]\n",
-    "\n",
-    "    snapshot.angles.resize(24)\n",
-    "    snapshot.angles.typeid[0:2] = 2\n",
-    "    snapshot.angles.typeid[2] = 1\n",
-    "    snapshot.angles.typeid[3] = 2\n",
-    "    snapshot.angles.typeid[4:8] = 1\n",
-    "    snapshot.angles.typeid[8] = 0\n",
-    "    snapshot.angles.typeid[9] = 2\n",
-    "    snapshot.angles.typeid[10:14] = 1\n",
-    "    snapshot.angles.typeid[14] = 0\n",
-    "    snapshot.angles.typeid[15] = 2\n",
-    "    snapshot.angles.typeid[16:21] = 1\n",
-    "    snapshot.angles.typeid[21:24] = 2\n",
-    "\n",
-    "    snapshot.angles.group[:] = [\n",
-    "        [1, 0, 2], [2, 0, 3], [2, 0, 4],\n",
-    "        [1, 0, 3], [1, 0, 4], [3, 0, 4],\n",
-    "        [0, 4, 5], [0, 4, 6], [0, 4, 7],\n",
-    "        [5, 4, 6], [5, 4, 7], [6, 4, 7],\n",
-    "        [4, 7, 8], [4, 7, 9], [4, 7, 10],\n",
-    "        [8, 7, 9], [8, 7, 10], [9, 7, 10],\n",
-    "        [7, 10, 11], [7, 10, 12], [7, 10, 13],\n",
-    "        [11, 10, 12], [11, 10, 13], [12, 10, 13]\n",
-    "    ]\n",
-    "\n",
-    "    snapshot.dihedrals.resize(27)\n",
-    "    snapshot.dihedrals.typeid[0:2] = 2\n",
-    "    snapshot.dihedrals.typeid[2] = 1\n",
-    "    snapshot.dihedrals.typeid[3:5] = 2\n",
-    "    snapshot.dihedrals.typeid[5] = 1\n",
-    "    snapshot.dihedrals.typeid[6:8] = 2\n",
-    "    snapshot.dihedrals.typeid[8:11] = 1\n",
-    "    snapshot.dihedrals.typeid[11] = 0\n",
-    "    snapshot.dihedrals.typeid[12:14] = 2\n",
-    "    snapshot.dihedrals.typeid[14] = 1\n",
-    "    snapshot.dihedrals.typeid[15:17] = 2\n",
-    "    snapshot.dihedrals.typeid[17:21] = 1\n",
-    "    snapshot.dihedrals.typeid[21:27] = 2\n",
-    "\n",
-    "    snapshot.dihedrals.group[:] = [\n",
-    "        [2, 0, 4, 5], [2, 0, 4, 6], [2, 0, 4, 7],\n",
-    "        [1, 0, 4, 5], [1, 0, 4, 6], [1, 0, 4, 7],\n",
-    "        [3, 0, 4, 5], [3, 0, 4, 6], [3, 0, 4, 7],\n",
-    "        [0, 4, 7, 8], [0, 4, 7, 9], [0, 4, 7, 10],\n",
-    "        [5, 4, 7, 8], [5, 4, 7, 9], [5, 4, 7, 10],\n",
-    "        [6, 4, 7, 8], [6, 4, 7, 9], [6, 4, 7, 10],\n",
-    "        [4, 7, 10, 11], [4, 7, 10, 12], [4, 7, 10, 13],\n",
-    "        [8, 7, 10, 11], [8, 7, 10, 12], [8, 7, 10, 13],\n",
-    "        [9, 7, 10, 11], [9, 7, 10, 12], [9, 7, 10, 13]\n",
-    "    ]\n",
-    "\n",
-    "    snapshot.pairs.resize(27)\n",
-    "    snapshot.pairs.typeid[0:1] = 0\n",
-    "    snapshot.pairs.typeid[1:11] = 1\n",
-    "    snapshot.pairs.typeid[11:27] = 2\n",
-    "    snapshot.pairs.group[:] = [\n",
-    "        # CCCC\n",
-    "        [0, 10],\n",
-    "        # HCCC\n",
-    "        [0, 8], [0, 9], [5, 10], [6, 10],\n",
-    "        [1, 7], [2, 7], [3, 7],\n",
-    "        [11, 4], [12, 4], [13, 4],\n",
-    "        # HCCH\n",
-    "        [1, 5], [1, 6], [2, 5], [2, 6], [3, 5], [3, 6],\n",
-    "        [5, 8], [6, 8], [5, 9], [6, 9],\n",
-    "        [8, 11], [8, 12], [8, 13], [9, 11], [9, 12], [9, 13]\n",
-    "    ]\n",
-    "\n",
-    "    hoomd.init.read_snapshot(snapshot)\n",
-    "\n",
-    "    ### Set interactions\n",
-    "    nl_ex = hoomd.md.nlist.cell()\n",
-    "    nl_ex.reset_exclusions(exclusions = [\"1-2\", \"1-3\", \"1-4\"])\n",
-    "\n",
-    "    lj = hoomd.md.pair.lj(r_cut = 12.0, nlist = nl_ex)\n",
-    "    lj.pair_coeff.set('C', 'C', epsilon = 0.07, sigma = 3.55)\n",
-    "    lj.pair_coeff.set('H', 'H', epsilon = 0.03, sigma = 2.42)\n",
-    "    lj.pair_coeff.set('C', 'H', epsilon = numpy.sqrt(0.07*0.03), sigma = numpy.sqrt(3.55*2.42))\n",
-    "\n",
-    "    coulomb = hoomd.md.charge.pppm(hoomd.group.charged(), nlist = nl_ex)\n",
-    "    coulomb.set_params(Nx = 64, Ny = 64, Nz = 64, order = 6, rcut = 12.0)\n",
-    "\n",
-    "    harmonic = hoomd.md.bond.harmonic()\n",
-    "    harmonic.bond_coeff.set(\"CC\", k = 2*268.0, r0 = 1.529)\n",
-    "    harmonic.bond_coeff.set(\"CH\", k = 2*340.0, r0 = 1.09)\n",
-    "\n",
-    "    angle = hoomd.md.angle.harmonic()\n",
-    "    angle.angle_coeff.set(\"CCC\", k = 2*58.35, t0 = 112.7 * pi / 180)\n",
-    "    angle.angle_coeff.set(\"CCH\", k = 2*37.5, t0 = 110.7 * pi / 180)\n",
-    "    angle.angle_coeff.set(\"HCH\", k = 2*33.0, t0 = 107.8 * pi / 180)\n",
-    "\n",
-    "\n",
-    "    dihedral = hoomd.md.dihedral.opls()\n",
-    "    dihedral.dihedral_coeff.set(\"CCCC\", k1 = 1.3, k2 = -0.05, k3 = 0.2, k4 = 0.0)\n",
-    "    dihedral.dihedral_coeff.set(\"HCCC\", k1 = 0.0, k2 = 0.0, k3 = 0.3, k4 = 0.0)\n",
-    "    dihedral.dihedral_coeff.set(\"HCCH\", k1 = 0.0, k2 = 0.0, k3 = 0.3, k4 = 0.0)\n",
-    "\n",
-    "    lj_special_pairs = hoomd.md.special_pair.lj()\n",
-    "    lj_special_pairs.pair_coeff.set(\"CCCC\", epsilon = 0.07, sigma = 3.55, r_cut = 12.0)\n",
-    "    lj_special_pairs.pair_coeff.set(\"HCCH\", epsilon = 0.03, sigma = 2.42, r_cut = 12.0)\n",
-    "    lj_special_pairs.pair_coeff.set(\"HCCC\",\n",
-    "        epsilon = numpy.sqrt(0.07 * 0.03), sigma = numpy.sqrt(3.55 * 2.42), r_cut = 12.0\n",
-    "    )\n",
-    "\n",
-    "    coulomb_special_pairs = hoomd.md.special_pair.coulomb()\n",
-    "    coulomb_special_pairs.pair_coeff.set(\"CCCC\", alpha = 0.5, r_cut = 12.0)\n",
-    "    coulomb_special_pairs.pair_coeff.set(\"HCCC\", alpha = 0.5, r_cut = 12.0)\n",
-    "    coulomb_special_pairs.pair_coeff.set(\"HCCH\", alpha = 0.5, r_cut = 12.0)\n",
-    "\n",
-    "    hoomd.md.integrate.mode_standard(dt = dt)\n",
-    "    integrator = hoomd.md.integrate.nvt(group = hoomd.group.all(), kT = kT, tau = 100*dt)\n",
-    "    integrator.randomize_velocities(seed = 42)\n",
-    "\n",
-    "    return hoomd.context.current"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "3UrzENm_oo6U"
-   },
-   "source": [
-    "\n",
-    "Next, we load PySAGES and the relevant classes and methods for our problem\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "id": "fpMg-o8WomAA"
-   },
-   "outputs": [],
-   "source": [
-    "from pysages.grids import Grid\n",
-    "from pysages.colvars import DihedralAngle\n",
-    "from pysages.methods import FUNN\n",
-    "\n",
-    "import pysages"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "LknkRvo1o4av"
-   },
-   "source": [
-    "\n",
-    "The next step is to define the collective variable (CV). In this case, we choose the central dihedral angle.\n",
-    "\n",
-    "We also define a grid to bin our CV space, the topology (tuple indicating the number of\n",
-    "nodes of each hidden layer) for our neural network which will model the free energy.\n",
-    "\n",
-    "The appropriate number of bins depends on the complexity of the free energy landscape,\n",
-    "a good rule of thumb is to choose between 20 to 100 bins along each CV dimension\n",
-    "(using higher values for more rugged free energy surfaces), but it can be systematically\n",
-    "found trying different values for short runs of any given system.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "id": "B1Z8FWz0o7u_"
-   },
-   "outputs": [],
-   "source": [
-    "cvs = [DihedralAngle([0, 4, 7, 10])]\n",
-    "grid = Grid(lower=(-pi,), upper=(pi,), shape=(64,), periodic=True)\n",
-    "\n",
-    "topology = (14,)\n",
-    "method = FUNN(cvs, grid, topology)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Fz8BfU34pA_N"
-   },
-   "source": [
-    "\n",
-    "We now simulate $5\\times10^5$ time steps.\n",
-    "Make sure to run with GPU support, otherwise, it can take a very long time.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "K951m4BbpUar",
-    "outputId": "f3e79872-41da-479a-caec-5bca7a6792e5"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "HOOMD-blue v2.9.7 CUDA (11.1) DOUBLE HPMC_MIXED SSE SSE2 \n",
-      "Compiled: 01/26/2022\n",
-      "Copyright (c) 2009-2019 The Regents of the University of Michigan.\n",
-      "-----\n",
-      "You are using HOOMD-blue. Please cite the following:\n",
-      "* J A Anderson, J Glaser, and S C Glotzer. \"HOOMD-blue: A Python package for\n",
-      "  high-performance molecular dynamics and hard particle Monte Carlo\n",
-      "  simulations\", Computational Materials Science 173 (2020) 109363\n",
-      "-----\n",
-      "HOOMD-blue is running on the following GPU(s):\n",
-      " [0]              Tesla T4  40 SM_7.5 @ 1.59 GHz, 15109 MiB DRAM, MNG\n",
-      "notice(2): Group \"all\" created containing 14 particles\n",
-      "notice(2): -- Neighborlist exclusion statistics -- :\n",
-      "notice(2): Particles with 7 exclusions             : 6\n",
-      "notice(2): Particles with 10 exclusions             : 6\n",
-      "notice(2): Particles with 13 exclusions             : 2\n",
-      "notice(2): Neighbors included by diameter          : no\n",
-      "notice(2): Neighbors excluded when in the same body: no\n",
-      "notice(2): Group \"charged\" created containing 14 particles\n",
-      "-----\n",
-      "You are using PPPM. Please cite the following:\n",
-      "* D N LeBard, B G Levine, S A Barr, A Jusufi, S Sanders, M L Klein, and A Z\n",
-      "  Panagiotopoulos. \"Self-assembly of coarse-grained ionic surfactants\n",
-      "  accelerated by graphics processing units\", Journal of Computational Physics 8\n",
-      "  (2012) 2385-2397\n",
-      "-----\n",
-      "** starting run **\n",
-      "notice(2): charge.pppm: RMS error: 1.29239e-08\n",
-      "Time 00:00:17 | Step 1 / 500000 | TPS 0.0732032 | ETA 1897:18:05\n",
-      "Time 00:00:27 | Step 7592 / 500000 | TPS 758.816 | ETA 00:10:48\n",
-      "Time 00:00:37 | Step 13193 / 500000 | TPS 560.085 | ETA 00:14:29\n",
-      "Time 00:00:47 | Step 20640 / 500000 | TPS 744.654 | ETA 00:10:43\n",
-      "Time 00:00:57 | Step 28318 / 500000 | TPS 767.734 | ETA 00:10:14\n",
-      "Time 00:01:07 | Step 35850 / 500000 | TPS 753.193 | ETA 00:10:16\n",
-      "Time 00:01:17 | Step 43551 / 500000 | TPS 770.023 | ETA 00:09:52\n",
-      "Time 00:01:27 | Step 51318 / 500000 | TPS 776.692 | ETA 00:09:37\n",
-      "Time 00:01:37 | Step 59324 / 500000 | TPS 800.505 | ETA 00:09:10\n",
-      "Time 00:01:47 | Step 67114 / 500000 | TPS 778.955 | ETA 00:09:15\n",
-      "Time 00:01:57 | Step 75064 / 500000 | TPS 794.909 | ETA 00:08:54\n",
-      "Time 00:02:07 | Step 83021 / 500000 | TPS 795.668 | ETA 00:08:44\n",
-      "Time 00:02:17 | Step 90477 / 500000 | TPS 745.559 | ETA 00:09:09\n",
-      "Time 00:02:27 | Step 98335 / 500000 | TPS 785.723 | ETA 00:08:31\n",
-      "Time 00:02:37 | Step 106243 / 500000 | TPS 790.778 | ETA 00:08:17\n",
-      "Time 00:02:47 | Step 114040 / 500000 | TPS 779.622 | ETA 00:08:15\n",
-      "Time 00:02:57 | Step 121787 / 500000 | TPS 774.697 | ETA 00:08:08\n",
-      "Time 00:03:07 | Step 129815 / 500000 | TPS 802.792 | ETA 00:07:41\n",
-      "Time 00:03:17 | Step 137806 / 500000 | TPS 799.042 | ETA 00:07:33\n",
-      "Time 00:03:27 | Step 145757 / 500000 | TPS 795.059 | ETA 00:07:25\n",
-      "Time 00:03:37 | Step 153686 / 500000 | TPS 792.881 | ETA 00:07:16\n",
-      "Time 00:03:47 | Step 161675 / 500000 | TPS 798.876 | ETA 00:07:03\n",
-      "Time 00:03:57 | Step 169735 / 500000 | TPS 805.934 | ETA 00:06:49\n",
-      "Time 00:04:07 | Step 177705 / 500000 | TPS 796.984 | ETA 00:06:44\n",
-      "Time 00:04:17 | Step 185701 / 500000 | TPS 799.506 | ETA 00:06:33\n",
-      "Time 00:04:27 | Step 193732 / 500000 | TPS 803.083 | ETA 00:06:21\n",
-      "Time 00:04:37 | Step 201721 / 500000 | TPS 798.886 | ETA 00:06:13\n",
-      "Time 00:04:47 | Step 209788 / 500000 | TPS 806.638 | ETA 00:05:59\n",
-      "Time 00:04:57 | Step 217359 / 500000 | TPS 757.091 | ETA 00:06:13\n",
-      "Time 00:05:07 | Step 225288 / 500000 | TPS 792.851 | ETA 00:05:46\n",
-      "Time 00:05:17 | Step 233355 / 500000 | TPS 806.656 | ETA 00:05:30\n",
-      "Time 00:05:27 | Step 241340 / 500000 | TPS 798.445 | ETA 00:05:23\n",
-      "Time 00:05:37 | Step 249323 / 500000 | TPS 798.266 | ETA 00:05:14\n",
-      "Time 00:05:47 | Step 257155 / 500000 | TPS 783.125 | ETA 00:05:10\n",
-      "Time 00:05:57 | Step 265070 / 500000 | TPS 791.422 | ETA 00:04:56\n",
-      "Time 00:06:07 | Step 272750 / 500000 | TPS 767.941 | ETA 00:04:55\n",
-      "Time 00:06:17 | Step 280712 / 500000 | TPS 796.126 | ETA 00:04:35\n",
-      "Time 00:06:27 | Step 288704 / 500000 | TPS 799.14 | ETA 00:04:24\n",
-      "Time 00:06:37 | Step 296196 / 500000 | TPS 749.197 | ETA 00:04:32\n",
-      "Time 00:06:47 | Step 304149 / 500000 | TPS 795.218 | ETA 00:04:06\n",
-      "Time 00:06:57 | Step 311950 / 500000 | TPS 780.038 | ETA 00:04:01\n",
-      "Time 00:07:07 | Step 319783 / 500000 | TPS 783.286 | ETA 00:03:50\n",
-      "Time 00:07:17 | Step 327627 / 500000 | TPS 784.356 | ETA 00:03:39\n",
-      "Time 00:07:27 | Step 335660 / 500000 | TPS 803.279 | ETA 00:03:24\n",
-      "Time 00:07:37 | Step 343705 / 500000 | TPS 804.431 | ETA 00:03:14\n",
-      "Time 00:07:47 | Step 351772 / 500000 | TPS 806.675 | ETA 00:03:03\n",
-      "Time 00:07:57 | Step 359884 / 500000 | TPS 811.15 | ETA 00:02:52\n",
-      "Time 00:08:07 | Step 368008 / 500000 | TPS 812.378 | ETA 00:02:42\n",
-      "Time 00:08:17 | Step 376084 / 500000 | TPS 807.507 | ETA 00:02:33\n",
-      "Time 00:08:27 | Step 384167 / 500000 | TPS 808.24 | ETA 00:02:23\n",
-      "Time 00:08:37 | Step 392255 / 500000 | TPS 808.744 | ETA 00:02:13\n",
-      "Time 00:08:47 | Step 400350 / 500000 | TPS 809.48 | ETA 00:02:03\n",
-      "Time 00:08:57 | Step 408442 / 500000 | TPS 809.159 | ETA 00:01:53\n",
-      "Time 00:09:07 | Step 416511 / 500000 | TPS 806.825 | ETA 00:01:43\n",
-      "Time 00:09:17 | Step 424601 / 500000 | TPS 808.994 | ETA 00:01:33\n",
-      "Time 00:09:27 | Step 432658 / 500000 | TPS 805.625 | ETA 00:01:23\n",
-      "Time 00:09:37 | Step 440748 / 500000 | TPS 808.96 | ETA 00:01:13\n",
-      "Time 00:09:47 | Step 448902 / 500000 | TPS 815.32 | ETA 00:01:02\n",
-      "Time 00:09:57 | Step 456957 / 500000 | TPS 805.407 | ETA 00:00:53\n",
-      "Time 00:10:07 | Step 465002 / 500000 | TPS 804.458 | ETA 00:00:43\n",
-      "Time 00:10:17 | Step 472850 / 500000 | TPS 784.792 | ETA 00:00:34\n",
-      "Time 00:10:27 | Step 480630 / 500000 | TPS 777.989 | ETA 00:00:24\n",
-      "Time 00:10:37 | Step 488708 / 500000 | TPS 807.714 | ETA 00:00:13\n",
-      "Time 00:10:47 | Step 496698 / 500000 | TPS 798.906 | ETA 00:00:04\n",
-      "Time 00:10:51 | Step 500000 / 500000 | TPS 814.111 | ETA 00:00:00\n",
-      "Average TPS: 771.893\n",
-      "---------\n",
-      "-- Neighborlist stats:\n",
-      "82167 normal updates / 1667 forced updates / 0 dangerous updates\n",
-      "n_neigh_min: 0 / n_neigh_max: 6 / n_neigh_avg: 3.85714\n",
-      "shortest rebuild period: 2\n",
-      "-- Cell list stats:\n",
-      "Dimension: 3, 3, 3\n",
-      "n_min    : 0 / n_max: 14 / n_avg: 0.518519\n",
-      "** run complete **\n"
-     ]
-    }
-   ],
-   "source": [
-    "method.run(generate_context, int(5e5))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "PXBKUfK0p9T2"
-   },
-   "source": [
-    "\n",
-    "Since the neural network learns the gradient of the free energy, we need a separate way of integrating it to find the free energy surface. Let's plot first the gradient of the free energy.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "id": "X69d1R7OpW4P"
-   },
-   "outputs": [],
-   "source": [
-    "from pysages.approxfun import compute_mesh\n",
-    "from pysages.ml.utils import pack, unpack\n",
-    "\n",
-    "import matplotlib.pyplot as plt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "id": "6W7Xf0ilqAcm"
-   },
-   "outputs": [],
-   "source": [
-    "xi = (compute_mesh(grid) + 1) / 2 * grid.size + grid.lower\n",
-    "\n",
-    "model = method.model\n",
-    "layout = unpack(model.parameters)[1]\n",
-    "\n",
-    "state = method.context[0].sampler.state\n",
-    "nn = state.nn\n",
-    "params = pack(nn.params, layout)\n",
-    "dA = nn.std * model.apply(params, xi.reshape(-1, 1)) + nn.mean"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 300
-    },
-    "id": "TBiPAnMwqEIF",
-    "outputId": "3a13a52d-2bd8-4122-db13-18bc6a11c797"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7090272950>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "T-Qkg9C9n7Cc"
+      },
+      "source": [
+        "# Setting up the environment\n",
+        "\n",
+        "First, we are setting up our environment. We use an already compiled and packaged installation of HOOMD-blue and the DLExt plugin.\n",
+        "We copy it from Google Drive and install PySAGES for it."
       ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
     },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEKCAYAAAASByJ7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3zb13Xw/88BuPce4qa2RC2KsqzhpTiJ7ThxmuW4znCS1mmfJ6Nt0jSj40nza5o2TZv8muZp3cQZTuo0iZ3h1iuO7diSbGtZojg0SEqUuMQhEuBeuM8fAFRapiSQBPD9Ajjv14svWxL4/R5w4ODec++5YoxBKaWUclgdgFJKKXvQhKCUUgrQhKCUUspHE4JSSilAE4JSSimfOKsDWIq8vDxTWVlpdRhKKRVRDh8+3G+Myb/87yM6IVRWVnLo0CGrw1BKqYgiIu3z/b1OGSmllAI0ISillPLRhKCUUgrQhKCUUspHE4JSSilAE4JSSikfTQhKKaUATQhKRazJmVkePdLBkXODVoeiokREb0xTKhYNT0zzH6+c4zt7z9A7PElKgpP/vH8HG0ozrQ5NRTgdISgVIYbGpvi7J0+w8yvP8rdPnGBlYRrfureW7JQEPvS9A5wbGLM6RBXhdISgVIT4o/88ym9P9XFHTTF/cNPySyOCVYXpvOtf9/PB7x7gkT/cSU5qgsWRqkilIwSlIkD7wCjPn+zjE3tW8i/31r5memhFQRrf/kAdXUPjfOT7BxmfmrUwUhXJNCEoFQEePnAep0O457ryef+9rjKHb7x3C0fPD/Hxh19lZtYT5ghVNNCEoJTNTc14+Nnh8+xZU0BRZtIVH3dbTRFffNt6nmm+wDefawljhCpaaEJQyuaebuqhf2SK390+/+hgrg/sqOQtG4v5t9+2ccE9EYboVDTRhKCUzf3HK+coyUrmxpWvO89kXn/25jXMeDz8069PhTgyFW00IShlY219I+xvHeCe68pwOiSgzynPTeH911fyk0PnOXVhOMQRqmiiCUEpG3v4wDniHMJ76soW9Hkf37OC1MQ4vvLEiRBFpqKRJgSlbGpiepafHe7g1rWFFGRcuZg8n+zUBP73LSt49kQv+1v7QxShija2SggikiUiPxOREyLSLCI7rI5JKas81djD4Ng0915/7WLyfO7bWcmyzCS+/HgzHo8JcnQqGtkqIQDfAJ40xqwBNgHNFsejlGV+9Mo5ynNS2LU8b1GfnxTv5NNvXk1Dp5vH6ruCHJ2KRrZJCCKSCdwIfAfAGDNljBmyNiqlrNHSO8yBMxe557pyHAEWk+fz9s0lrCvO4O+fPMnEtO5gDoXxqVmmo2QjoJ16GVUBfcB3RWQTcBj4pDFmdO6DROR+4H6A8vLFDaWVsrufv9qJ0yG8u650SddxOITP37GW933nFX56uIP3X18RpAgVwKvnBnn3v77EjMeQGOcgPSmejKQ4KnJT+Np7NkdcXynbjBDwJqda4P8aY7YAo8BnL3+QMeYBY0ydMaYuPz+wddlKRZq9LQNsKcsiLy1xydfatSKXTaWZfHffGa0lBJExhi/9VxPZqQl86o2ruG9nJW9cV8i6ZRnsaxngMz87hjGR9fW20wihA+gwxrzi+/PPmCchKBXtXOPTHO8Y4mN7VgbleiLCh3dX8ckfH+W3p/u4ZXVBUK4b6x4/3sORc0P83Ts3cPe2185WPLj3DH/9X018f/9Z7ttVZVGEC2ebEYIxpgc4LyKrfX/1BqDJwpCUssTLbQN4DOxesbhi8nxurymmMCORB/eeCdo1Y9nkzCxfebKZNUXpvGvr6/eIfGhXJXvWFPDlx0/Q1OW2IMLFsU1C8Pk48CMRqQc2A1+2OB6lwm5fSz/J8U42l2UF7ZoJcQ4+sKOSF0/36+7lIPjB/nbOXxzn83esnXcHuYjw1XdtJCslno8/fISxqRkLolw4WyUEY8xRX31gozHm7cYYPSxWxZy9Lf1sr84hIS64v573XFdOYpyD7+47G9TrxprB0Sn++dnT3LQqnxtXXbmOmZuWyNfv3kxb/yhf/FVkTHbYKiEoFeu6XeO09Y0ueu/B1eSkJvCO2hIePdLB4OhU0K8fK/7/Z08zMjnDF96y9pqP3bkij/9183L+89B5Hjtm/70gmhCUspF9LQMA7Api/WCuD+2qYnLGw38cOBeS60e7M/2jPPRSO3dvK2dVYXpAn/NHt65iS3kWf/6LBkYn7T11pAlBKRvZ39JPbmoCa4oCe7FZqFWF6dywMo8fvHSWqZno2EwVTl95opnEOAd//MbAV4DFOx38xZ3rcI1P88iRjhBGt3SaEJSyCWMMe1v62bE8d0m7k6/lw7uruOCe5ImG7pDdIxr1uCZ4qvECH7mhmoL0hTUbrC3PZlNZFt/dd9bWe0E0IShlE619I/QOTwZ1uel8blqZT3V+Kt/ZeybiNk5ZaV+Lt2vsbeuLFvX5H95VyZn+UZ4/1RvMsIJKE4JSNrH3tPcFJ1T1Az+HQ/jQzkrqO1wc73SF9F7RZF9rPzlLmM67Y4N3L4idV3lpQlDKJva2DFCek0JZTkrI7/W2zSUkOB384lX7r3yxA2MM+1sG2FG9+Om8eKf994JoQlDKBmZmPbzSNsCuFblhuV9mcjy3rMnnsfouZm08p20Xbf2j9Lgn2LnE78//7AWx545xTQhK2UB9p4vhyZmQTxfNddfmEvqGJ3m5bSBs94xU+331g6XuD8lJTeB3tpTw6JFOW+4F0YSglA34X3B2VIdnhACwZ00BaYlx/OLVzrDdM1LtaxmgJCuZitylT+fZeS+IJgSlbGBvSz/rijPIDUK760AlxTu5raaIJxt69PCcq/B4DC+1DbBzeS4iS18OvLoond0r8njopXbbHayjCUEpi41PzXKkfShs9YO57tq8jOHJGZ4/ad+lkFZr6nbjGp8O6nTeh3ZV0uOe4ImGnqBdMxg0IShlsUPtF5ma9bAzjPUDvx3VueSlJepqo6vw7z/YuTx4CfuW1QVU5aXy0Etng3bNYNCEoJTF6ju8ewFqy7PDfu84p4O3birm2ZO9uManw37/SLCvdYCVBWkUZCxsd/LVOBzCO7aUcPDsID2uiaBdd6k0IShlsYZOFxW5KWQmx1ty/7s2lzA14+Epm01f2MHUjIeDZy6GZPXX7RuKAXiq0T5fd00ISlmsoctFzbJMy+6/qTSTitwUfnlMVxtd7tVzg4xPzwZ1ushvRUEaqwrTePy4fXpKaUJQykKusWnOXxxnfUmGZTGICHdtWsb+1gF63faZvrCDfa0DOAS2h2g58G01xRw4e5G+4cmQXH+hNCEoZaHGLm/9wMoRAnhbWRgDv4qAQ1zCaX9LPxtKMkM2nXfHhiKMsc+0kSYEpSzU6DuAff0y60YI4J2+qCnJ4JdHNSH4jU7OcPT8UEhXf60uTKc6L5UnbVK/0YSglIUaulwsy0wK64a0K3nrxmUc73TROTRudSi2cODsRWY8JiTHmfqJCLdvKOKltgEu2qCVhe0Sgog4ReRVEfkvq2NRKtQaOl2sL7F2usjvDWsLAHjuhG5SA+90UUKcg7rK0C4Hvr2mmFmP4ddN1o8SbJcQgE8CzVYHEcvO9I/y6Z8e48i5QatDiWqjkzO09Y9aXj/wW56fRllOsiYEn/2tA2wtzyYp3hnS+6xflkFZTjKPH9eE8BoiUgq8Bfi21bHEIo/H8P39Z7n9Gy/ws8MdvP/br/CKdsIMmeZuN8ZAjYUrjOYSEfasLmBfa3/M9zaamJ7lRM8wWytCv1lQRLijpph9Lf24xqzdHGirhAB8HfgMcMWOTyJyv4gcEpFDfX194YssynUNjfOBBw/wV79qZHtVLr/62C6KMpO477sHL3XiVMHV4DutbL1NRggAt6wpYGLaw0sx/kbgZM8wsx4TtmR9+4ZiZjyGXzdfCMv9rsQ2CUFE7gR6jTGHr/Y4Y8wDxpg6Y0xdfn5+mKKLbo8d6+LNX3+BI+cG+ZvfqeF7H9rGxtIsfnz/DspykvnQ9w7ywilNvsHW0OUmLy2BwgzrC8p+11fnkhzvjPlpo/9Z/RWeZL2pNJNlmUk82WDtJjXbJARgF/A2ETkL/BjYIyI/tDak6NfrnuCP//MoKwrSeOKTN3Dv9opLLX7z0xN5+Pevpyovld/7/iGePWHtu5do09DpYv2yzKC0VA6WpHgnu1bk8uyJXoyJ3ZPUGrtcZCTFUZqdHJb7iQi31RTzwql+hiesmzayTUIwxnzOGFNqjKkE3gs8a4x5n8VhRb2HD5xnxmP4p/dspiI39XX/npvmTQqritL46EOHaem151mwkWZiepbTvSO2qR/MdcuaAjoGx2npHbE6FMs0dLlZtywjrMn6jg1FTM16eNbC0ZltEoIKv+lZD/9xoJ2bVuVTmff6ZOCXnZrAg/dtwxj4yaGOMEYYvS7NUduofuB3y2rv8lMrX5isNDPr4US3O+zfm9rybPLTE3m60bqRuC0TgjHmeWPMnVbHEe2eabrABfck77++4pqPLUhP4ubVBfz81U5mbHbKUyTyz1HX2GQPwlzLspJZU5QeswmhrX+UyRlP2PtLORzCDSvz2N/aj8djzXSdLROCCo+HXm6nJCuZW9YUBPT4d9Z6D2Xf1xrbK1CCoSHMc9QLtWdNAYfaB2PyjAQrV3/tXpHH4Ng0Td3usN8bNCHErJbeYfa3DnDv9eU4HYHNk+5ZW0BmcjyPHtFpo6Vq7HRRU2KvgvJce9YUMOsxvHg69laXNXa5SYp3UH2VadRQ8Z+7sM+ipd6aEGLUD18+R4LTwd11ZQF/TmKck7duKuapxh5LV0JEuulZD809w7acLvLbUp5NVko8z52IvYTQ0OliTVEGcc7wvzwWZiSxsiCNvZoQVLiMTs7wyOEO3rKxeMFN1d5RW8rEtIcnbLDNPlK19I4wNeOxvMPp1Tgdwk2r8vntqV7L5rOtYIyhqdtt6fdm14o8Dp69aMlucU0IMegXRzsZnpzhfQEUky+3pSyL6rxUHtFpo0Xzz1HbeYQA3mmj/pEp6n3xxoLzF8cZnpix9Htzw8o8JqY9lvQS04QQY4wxPPRSO+uXZVBbnrXgzxcR3lFbwitnLnL+4lgIIox+jV1uUhOcVM2z78NOblqVj0Nia/lpQ5e/oGzdCGF7dS5Oh1hSR9CEEGMOtQ9yomeY919fseiC5tu3lADw81f1DN7FaOh0sW5ZBo4Ai/lWyUpJoLY8m+dPxk5CaOxy4XQIqwrTLYshLTGOLWVZ7G0J/2o+TQgx5ocvt5OeFMddm0sWfY3S7BR2VOfy6JGOmG5vsBizHv8ctb2ni/x2r8yjodNleRfOcGnscrOyIC3kLa+vZdeKPI53DIX9664JIYZ4PIbnT/Zxe00RyQlL+4F/R20JZwfGOHJuKEjRxYb2gVHGpmZtXVCea0d1Lh4Dr5yJjb0nDZ32SNa7V+bhMYS966wmhBjS3OPGNT7NjuW5S77W7RuKSY536p6EBfL3B7JySmIhNpdnkRjniIl22L3uCfpHJm2RrDeXZZGa4Ax7HUETQgx5ue0i4G1xvFRpiXHcVlPEY8e6mJrRVhaBau0bBaA6394FZb/EOCfbKnN4KQZ2p/sLynZY/RXvdLC9OlcTggqdl1oHqMxNoTgzOO0S3riuEPfEDI1dsbMscala+0YozEgkPSne6lACtmN5Lid6hm1xCHwoNXZ620WsLbbH6G3Xijza+kfpHBoP2z01IcSIWY/hwJmBoIwO/Op8xwsebtezlwPV2jfC8vw0q8NYEP/PzMtRPm3U2OWmMjfFNsl6twVtLDQhxIjmbjfuiZmgJoSCjCTKc1I4dFYTQiCMMbT0Rl5C2FiaSUqCM+qnjRq6XKy3wXSR36rCNPLSEjUhqODzv7vbXp0T1OvWVWRzqP2iLj8NQN/IJMMTMyyPkPqBX7zT4a0jRPEIwTU2TcfguC0Kyn4iwu4V3jpCuH6/NCHEiJfbLga1fuBXV5lD/8gU7QO6a/laWnu9BeXlBZE1QgDYuTyXlt4ReocnrA4lJBq7rWt5fTW7VuTRPzLFyQvhOalQE0IMCEX9wK+u0ltHOHj2YtCvHW1a+7xLTiNtygi4tFQ5WqeN/AVlO40QYG477PB83TUhxIBQ1A/8VuSnkZEUp4XlALT2jZCS4KQoI8nqUBZs/bJM0pPioraw3NjloigjibwFdv8NtWVZyZRmJ3O4PTxvuDQhxAD/L3EoEoLDIdRV5nBIE8I1tfaNUp2favseRvNxOoTtVdG7H6Gp2806m40O/LZWZHPo7GBY6gi2SQgiUiYiz4lIk4g0isgnrY4pWrzcNkBVXipFmaF5Z7q1IpuW3hEGo3yd+lK19o6wIgKni/x2LM/j7MAYXWFcFx8OE9OztPaNsq7YngmhriKb3uFJOgZD/3W3TUIAZoBPGWPWAdcD/1tE1lkcU8Sb9RheOXOR64O8umgu3Y9wbeNTs3QOjUdk/cBvR3V01hFOXxhh1mNsO0Ko9f1+heN8BNskBGNMtzHmiO//h4FmYPEtORXgrR8Mh6h+4LepLIt4p3AwTPOckehSQTkCVxj5rSlKJzslPuqWnzb5VhittekIYXVhOqkJzrDs97FNQphLRCqBLcAr1kYS+S7tP6gKXUJIindSU5LJYd2gdkWRvMLIz+EQtlflRt0Iobl7mJQEJxU5KVaHMq84p4Mt5dlhGYHbLiGISBrwCPBHxhj3PP9+v4gcEpFDfX2xdwD4QoW6fuBXV5FNfYfLknNgI0Fr3ygOgYpce77oBGrH8lw6h8aj6rS8pi43a4vtfWBRbUU2J3rcjEzOhPQ+tkoIIhKPNxn8yBjz6HyPMcY8YIypM8bU5efnhzfACBOO+oFfXWUOU7OeS+cFq9dq7RuhLCfF8oNXlmqnbz/C/tbwH+8YCsYYmrvdtmlodyV1Fdl4DBwN8fkjtkkI4j3P8TtAszHmH62OJxo0dYW+fuC31Vf40uWn82uNwB5G81lR4O2v42+lHuk6BscZnpxhXbG9dihfbnN5FiKhX7hhm4QA7ALeD+wRkaO+jzusDiqShXL/weXy0hKpzkvlkO5Yfp1Zj+FM/2jE9TCaj4hwXVV21OxMb+yyV8vrK8lIimd1YTqHQrxwwzYJwRiz1xgjxpiNxpjNvo/HrY4rkh1qv0hFbgqFYdoZu7XCW/jSRnev1TU0zuSMJypGCAB1FTl0DI7T7Yr8/QjN3W4cAmuK7LnCaK6tFdkcPTfErCd0v1+2SQgq+Bo63WwszQrb/eoqsxkcm750KpjyavGtMFoRwUtO59pW6a1JRUPb86ZuN1V5qUs+YzwctlZkMzw5w+ne0DW604QQpfpHJukcGmdjGPu71116oYiO6YRgae2N/CWnc60tTiclwRkV32f/CqNIUFcR+kSsCSFKHfet9tlQGr6EUJ2XSk5qghaWL9PaN0JOagLZqQlWhxIUcU4HteXZHIzwEYJrfJrOoXHb7lC+XFlOMnlpiRwJ4e+XJoQodbzD3989fD/sIkJtmDbQRJLW3ugoKM9VV+ldF++emLY6lEVr7vYWlO3aw+hyIsLWiqyQvuHShBCljne6qM5PDfv5sJvLMjnTP4prPHJfKIItEs9RvpZtlTl4DLwa4nXxoRRpCQG800bnLo6F7KAiTQhR6niHK6z1A78NviJ2o25QA2BwdIqB0amoSwiby7JwOiSi6whNXW7y0hLIT7fXGQhXc6nRXXtoErEmhCjU656gxz1x6cU5nDb4ktBxTQgAtPX7m9pF15RRamIc64ozIno/QlO3t6Ds3RMbGWpKMkiIc4TswBxNCFHoUkHZghFCTmoCJVnJmhB8Lp2jHGUjBPDWEY6eH2JqxmN1KAs2Pevh9IWRiJouAkiMc7KxJDNkdTpNCFHoeKcLEevOh91QkqkJwae1b4QEp4PS7MhuajefbZU5TEx7aOyKvO91a98IU7OeiFlhNNfWimwaOt0haSSpCSEKHe9wsSI/jdTEOEvuv6E0k/aBMS0sAy29I1TlpeK0cSfNxfIfjBSJG9T8BeVI2YMw19aK7JA1klxwQhCRVBGx/7a+GGWMob7TFdb9B5er8U1VaWHZ+040WnYoX64gI4mK3JSQ99cJhaYuNwlxDqrzIq+2s7Uim/ddX05GcvBXEF4zIYiIQ0R+V0T+W0R6gRNAt+/s46+KyIqgR6UW7YJ7kr7hSUvqB35aWPaanJnl3MUxqqNsD8JcdRU5YTsAPpiaut2sLkwnzhl5kyS5aYn8f2/fwKrC4DfkC+Sr8RywHPgcUGSMKTPGFAC7gZeBvxOR9wU9MrUo/hfhjRaOEPyF5foYTwjnBsbwGKI6IWyrzGZgdIoz/ZHTv8p7BsJwxBWUwyGQSeZbjTGvmww2xlzEe5jNI76DbZQNHO8YwiFY3t99Q0lmzB+W42/yV50XnVNGMLd/1SDVEbKS6oJ7koujUxFZUA61QEYIH7vWA+ZLGMoa9Z0uVhWmW9698VJheSx2fzT875qjeYSwPD+V7JT4iNqPEMkF5VBbUEIQkffO/QcRKRSR23WEYA/GGI53uC4Vda3kryM0ROCSxGBp6xshPz0x7O1DwklEqKvMiaiGhk2+hLDG5ofiWCGQhFAuIv6v3P+97N9+ANwN/CioUalF6XZNMDA6ZWn9wE8Ly9DWPxqRq1gWaltlNmf6R+kbnrQ6lIAc73BRkZtCRhQn6sUKJCFcBL4sIncBcSJy45x/KzbG3Ad8PxTBqYWp77Buh/LlsnXHMm19I1E9XeTnryOEqp1CsNV3DIX14KhIEkhCeDfwIvD7wLuAfxaRD4jIZ4BeAGPMf4cuRBWo451DxDnENnOjG0tjt7A8ODrF4Nh0VBeU/WqWZZIY54iI8xH6hifpck2wyQajaDu65iojY8wLvv/9CYCInAU+CiThTRLKJuo7XKwsTCcp3h77BmtKMnmioQfX2DSZKbE1PPc3tYuFEUJCnINNpVkRcQ7G8U5vl1A7jKLtKJCNaa/Zc2+MOWmM+RNjzP8yxpyZ7zGLJSK3ichJEWkRkc8G45qxwhhDQ6c1La+vJJYLy23+JacRshRzqWorsmnscoWkv04w1Xf4+nzZ6PfETgLamCYiHxeR8rl/KSIJIrJHRL4PfHCpgfjaYfwLcDuwDrhHRNYt9bqxomNwnMGxaUtbVlwulgvLbf2jxDuFsuxkq0MJi60V2UzPGtt/r/19vtIs6vNld4EkhNuAWeBhEenytaw4A5wG7gG+boz5XhBiuQ5oMca0GWOmgB8DdwXhujHBDjuUL5edmkBpdvKl4zxjSVvfCOU5KRHZGmExtvoa3dl52sgYw7EOa/t82V0gNYQJ4FvAt3z7DfKAcWNMsI/sKQHOz/lzB7D98geJyP3A/QDl5eWX/3PMauh0EecQVhfZa211rLbCbusbjZnpIvC2K6nOS/V2Pr3J6mjm1+OeoH9kkk26wuiKFvT2xRgzbYzp9icDEQn7V9YY84Axps4YU5efnx/u29tWU7ebFQVpJMbZo6Dst6E0k3MXY2vH8qzH0D4wFhN7EOaqrcjmyDn7Nrq7tCxbRwhXFFBC8LW8vk5EPiwiXxORp0SkEzgbxFg6gbI5fy71/Z0KQGOX25a9WWKxsNwxOMbUrCcmVhjNtbUim4ujU5wdGLM6lHnVd3iXZWtTuysLZJXRWeAU8DfAFqAV2ABsMcYEc4RwEFgpIlUikgC8F/hVEK8ftXqHJ+gbnmT9Mvu986nxxVQfQ3WEtv7YWmHk9z8H5thzg1p9h7fPl12WZdtRICOEx/DuVv53Y8zHjTHfAiaNMb3BDMQYM4O3b9JTQDPwE2NMYzDvEa2aury9Wez4zic7NYGynORL679jwaUlpzE2ZbQ8P42MpDiOnLNfYdkY7wooOy26sKNAisofF5EK4Isi8qfAXwIhmSQ0xjwOPB6Ka0czf7MuO04ZAWwszeLouVhKCCNkJseTk5pgdShh5XAItRXZtlxpdP7iOENj09qy4hoCqiEYY9p9PYvuw7s7uUhEbglhXGoBmrrclGYnkxmCI/WCYUtZFp1D4/QOT1gdSlh4VxilEqT9mhFla3k2py6M2G4RQb1vhKojhKsLtKj8JRGpMMY0GmPeAdwCfEFEfhva8ELjJwfP87lH660OI2iauty2nC7y21LufVcWK6OEtv4RqmJsushva6W3jnDkvL1GCfUdLhLiHCE5djKaBLrs9JPA077VRe8CDhtjbgX+OnShhc7ZgVF+eqjD9tvsAzE6OcOZgVFbFpT91i/LJM4hvHo++hPCyOQMF9yTLI+xgrLfptIsnA7hiM2mjeo7hlhbnEFCXGxsFFysQL86F4wxq4Gv4N093CIiX8W7eSzibCjJZMZjONkzbHUoS3aix40x9q0fACTFO1lbnBETI4Sz/bFZUPZLTYxjbXG6reoIHo+hodNtqz5fdhVoQjAAxpjnjDHvBzYCY0BDJPYbqomiHjv+FUbrbZwQwDttVN8xxKzHnpuWgqW1z9/lNDZHCAB1FTkcPT/EzKzH6lAA7zLgkckZrR8EYEHjJxFxiMjbgIfwnpT2F8CZUAQWSv4CbGMUbJZq7HKTlRJPcWaS1aFc1eayLEanZjndG/mjsqtp6xtFBCpyU6wOxTK1FdmMTc1ywiYj8OOXCsq6wuhaAk0IaSLyFaAN74axbxhj1hhjvmKMGQ9deKEhIlHTY6ep21tQtvuKls1lsVFYbusfpTQ7OaY3P9mt0d2x8y6S452sKIjdUVugAk0IF4FuoNYY87vGmGdDGFNYrC/J4GTPMJMzkVtYnpn1cKJn2PbTRQBVealkJsfzarQnhL6RmDgl7WqWZSZRlJHEIZskhOOdLmpKMnA67P2myQ4C3YdQY4z5hjHGnnvSF2FDSSbTs4bTF0asDmXRWvtGmZrx2Lqg7CcibC7L4mgUrzQyxnCmfzRml5z6iQhbK7NtsdJoZtZDY5eLDSU6XRSImF2D5e+xE8nTRk3d3tjtvOR0rs1lWZzqHWZkcsbqUELignuSsalZlsdYU7v5bC3PpnNonG6XtTPKp3tHmJj2sKksMn5HrBazCaEiN4X0pLiIPgS+sdNNQpwjYpY4binPwhioj9JRQpuuMLpk66VGd9aOEo0xIVAAAB1ISURBVI6d1zOUFyJmE4KIULMsM6ITQlO3mzVF6RFzKpe/sBytG9RaL3U5jYwEHUrrlmWQHO+0vPPpkXODZKfEx/w0XqAi45UkRGpKMmjuGWbaJuulF8IYQ1O3OyIKyn5ZKQlU5aVGbR2hrW+ElAQnRRn2XgIcDvFOB7UVWRyweIRwuH2QrRXZtl+FZxcxnhAymZrxRGRhucs1wdDYtK17GM1nS1kWr54bsu2pWkvR1uctKOuLj9d1lbmc6HHjGrem0d3g6BStfaPU+qav1LXFfEIAInLa6NIZCBFSUPbbXJ5F/8gknUMRt33lmlp6R7R+MMe2qmyMgcPt1kwb+c9l2FquCSFQMZ0QqnJTSUuMi8jjHRu7XIjAmqLI6t54aYNalE0bDU9M0zk0HnHfj1DaUpZNvFM4cMaaaaPD7YPEOUR3KC9ATCcEh0NYtywjIpeeNnW5qcpNJTXxmmcc2cqaIm/HyWjboHbKN+24WtsrX5Kc4KSmJJODFhWWD7cPsr4kk+SE2N01vlAxnRDAux+hudttm0ZcgWrsckfEhrTLJcQ52FCSGXUjhFMXvH17VusI4TWuq8yhvmMo7K3mp2c9HOsY0umiBYr5hLChNIOJaQ+tvnNwI4FrzDs9EYkJAbzTRg2dLqZmIisJX83JnmFSE5yUZCVbHYqtbKvMYXrWhP0NQHO3m4lpz6X9ECowMZ8QInHH8qUzlCNshZHf5rIsJmc8nOhxWx1K0JzocbOyMB2H9st5jTrfCWoHz4R32si/Ia62QusHC2GLhCAiXxWREyJSLyI/F5GwfRer89NIjndG1EqjSwkhQkcIl47UjJJpI2O8hy1pQfn1slISWF2YzoEw1xEOnxukJCuZ4kwdsS2ELRIC8GugxhizETgFfC5cN3b6CsuRlBCau93kpSVSkB6ZG6BKspIpSE+0vK1BsPSNTDI4Nq3n9V7Btipvo7tw1umO+DakqYWxRUIwxjxtjPF3PHsZKA3n/TeUZNLU7Y6Y07yautysLY7cFx8R4bqqHA6cuRgVG9RO9XhXGOkIYX7bKnMYnZqluTs8B+Z0DY3T7ZrQhLAItkgIl/kw8MSV/lFE7heRQyJyqK+vLyg3rCnJZGxqljP99t+xPD3roaV3JGLrB37bq3LocU9w/mLkb1Dz10J0hdH8rqvKAQjbtJH/YB5NCAsXtoQgIs+ISMM8H3fNecwXgBngR1e6jjHmAWNMnTGmLj8/Pyix1ZR4X1wbOu1f5GztG2FqNjLOQLia66pyAXjlzIDFkSzdyZ5h8tISyE1LtDoUWyrOTKY0OzlsheXD7YMkxzt1xLYIYUsIxphbfQftXP7xSwARuQ+4E7jXhHkeYUV+GolxjohYaeRvWbE2wkcIKwvSyEqJ55Uwrz4JhVMXhnV0cA3XVeZw8Gx4pggPtw+yuSwrYroA24ktvmIichvwGeBtxpixcN8/zunw7ljusH9CaO6OrDMQrsThEK6r9NYRIpnHYzh1YUQLytewrSqHgdEp2vpDu99nbGqGpm73peWuamFskRCAbwLpwK9F5KiI/Gu4A9hclkV955DtW2E3dbtZXRg5ZyBczXVVOZy7OGb5qVpLcX5wjPHpWZ2euIZtld46QqinjY6ddzHrMdrhdJFs8apijFlhjCkzxmz2ffxBuGPYUp7NxLSHkz3hWQmxGMYYmruHI3qF0VzbfXWESB4lnPD9vOgI4eqW56eSm5oQ8u+1v8NpbZkmhMWwRUKwg1rfZin/D5Qd9Q5PcnF0KuJXGPmtLU4nLTEuohPCSU0IARERtlXmhHyl0eH2QVYWpJGZEh/S+0QrTQg+JVnJ5Kcn2roLZ7QUlP3inA7qKrMjurB88sIw5TkpEdd11grbqnLoGBynK0RnYXg85tIJaWpxNCH4iAi15Vm2HiH4W1asjfAlp3NdV5VDS+8I/SOTVoeyKCd7hnV0EKBdK7xThC+eDs7+ocu19o3gGp/W+sESaEKYY0t5Nu0DYwzY9MWpudtNaXYyGUnRMxze7tu0ZPVh7IsxOTPLmf5RLSgHaHVhOkUZSTx/MjQJYW9LPwA7qnNDcv1YoAlhjlpf73S7Ths1dbujZrrIb0NJFolxjoicNmrtHWXWY1ilCSEgIsLNq/PZe7o/JKv5XjjVR3VeKmU5KUG/dqzQhDDHhpJM4hzCq+ftN200NjXDmf7RqCko+yXEOagtz47IwvLJC94pPB0hBO6mVfkMT85wpD24v2OTM7O83HaRG1bmBfW6sUYTwhzJCU7WFmdwpN1+I4STPcMYEz0F5bm2V+fQ1O3GNT5tdSgLcrJnhHinUBXhmwTDadfKPOIcwm9PBXfa6HD7IOPTs9ywMjjtbGKVJoTLbCnP4ljHkO06n/o7RUbbCAG8hWVj4HB7ZI0STva4WZ6fRnwUbBIMl4ykeGorsoNeR3jxdD9xDuH65Vo/WAr9Sb5MbXk2Y1Ozttug1tztJj0xjtLs6DvwY0tZNvFOibg6wqkLI9rDaBFuXp1PU7ebXvdE0K754uk+aiuySdPlv0uiCeEylwrLNqsjNHW7WVMcnUc0Jic42ViaFVF1BPeE91xrXXK6cDevKgDg+SBNGw2MTNLQ6eamVTpdtFSaEC5TlpNMbmqCreoIHo/hRLc7KqeL/K6ryuF4h4uxqZlrP9gGTl/wjiC1oLxwa4vTKUhPDFodwb/cVAvKS6cJ4TIiwpbybF610Qa184NjjE7NRmVB2W97VQ4zvp2mkUB7GC2eiHDTqnxePNUXlGM1XzzdT3ZKPOuXZQYhutimCWEeW8qzaOsfZXB0yupQgOhrWTGfusocnA7h5bbIODDnZM8wqQnOqKzphMPNqwtwT8xw9PzSRuLGGF483ceuFXk4o3A6Ndw0IczDX0dY6g9rsDR3u3FIdB/RmJYYx8bSTPa3RkZCONbhYv2yTET0RWgxdq/0voAvdbXRqQsjXHBPcqMuNw0KTQjz2FiaiUOwzbRRU7eb6vw0kuKdVocSUruW51Hf4WJ4wt77ESamZ2nsdLFVD2FZtMzkeGrLs5ZcR/D3Rdqt9YOg0IQwj9TEONYUZXDEJi0smruHo7qg7LdzeS6zHmP71Ub1HS5mPIat5ZoQluKmVfkc73TRN7z43mEvnO5nRUEay7J06i4YNCFcwZbyLI6et36DmmvMu7wxmusHfrUV2STEOdjXYu9pI3/he4vvDA21ODev9i4/fWGRo4SJ6VleaRvQ1UVBpAnhCmrLsxmZnKGld8TSOI53es95rimJ/oSQFO+kriKb/a39VodyVYfbB6nKSyU3LdHqUCLauuIM8tISF70f4dDZQSZnPFo/CCJNCFfgf/dndR3hWId32mpjSWy8G921Io8TPcO2bUFujOHIucFLCw/U4jkc3uWnL5zqY2J6dsGf/+LpPhKcDrZX54Qguthkq4QgIp8SESMilo8Bq/K8Z8C+ZPEyyOMdLipzU2LmSMAdvl40Vn/dr+TswBgXR6f0VK4geWdtCa7xaX7xaueCP/eF0/3UVWaTkqDtKoLFNglBRMqANwHnrI4FvJtn9qwp4NkTvUzNBL93e6DqO4bYUBobowOAjSWZpCXG2Xb5qb9+oAkhOHYsz2X9sgweeLENzwLqdc3dbpq73dy8WqeLgsk2CQH4J+AzgG3ajN5WU8TwxIxl71b7hifpck2wqTR2dmDGOR1sr8phf4s96wiH2wdJT4xjZUGa1aFEBRHh/huraesb5TcnegP+vG8+20J6Yhx315WHMLrYY4uEICJ3AZ3GmGNWxzLXrhV5pCY4ebKhx5L7H+/01g82lMROQgDYuSKPswNjdIboMPalONI+yJaK7KhsMmiVt2wopiQrmQdeaA3o8acvDPN4Qzcf3FkZM1Op4RK2hCAiz4hIwzwfdwGfB/4ywOvcLyKHRORQX19ozmb1S4p3csuaAn7d1GPJ8tNj5104BGpiLSH46gh2GyW4xqc51Tus+w+CLM7p4CO7qzh4dpAjASzi+OZzLSTHO/nI7qowRBdbwpYQjDG3GmNqLv8A2oAq4JiInAVKgSMiUnSF6zxgjKkzxtTl54d+/vC2miL6R6Ysabp2vNPFioI0UmOsx/vqwnRvQd9mdYSj54cwRusHoXD3tjIyk+N54LdtV31ca98Ijx3r4v07KshOTQhTdLHD8ikjY8xxY0yBMabSGFMJdAC1xhhr5mkuc/PqAhLiHGGfNjLGeAvKMbLcdC6H7+Sr/a0DGGObkhJH2gdxCGwqi60RWzikJsbx/usreKqphzP9o1d83L8810JCnIPfv6E6jNHFDssTgt2lJcZx48o8nmrsCeuLU7drgv6RqZh98dm1PI8e9wRtV3lxCLcj5wZZXZRBepLOW4fCB3dWEu908O0X5x8ltA+M8sujXdy7vYI83RQYErZLCL6Rgq0mj9+8vojOoXEafW2ow6G+IzYLyn6X6gg2mTaa9RhePTfE1orYG7GFS356Iu+sLeFnhzvon2dj4reea8XpED56o44OQsV2CcGObl1biNMhYZ02qu9wEeeQmOhhNJ+K3BSWZSbZprB86sIwI5MzWj8Isd+7oZqpWQ//8NRJTl0YvnSATsfgGI8c6eCebWUUZCRZHGX0iq1q5SJlpyZwfXUOTzb28Ok3rw7LPes7XKwpTo/6ltdXIiLsXJHHM80X8HiM5cs8L21IK9c2CaG0PD+Nt28u4ccHz/Pjg+dJiHOwqjANjwdE4KM3Lbc6xKimI4QA3ba+iJbeEVp6h0N+r1guKM+1c3kuQ2PTYZ2qu5Ij7YPkpSVSlqNtlkPtH969iSc+eQP/dPcm7ttZSXZKAn0jk/zeDdXa5jrEdIQQoDetL+IvftnIU40XWFEQ2pPL2gfGcE/MxNQO5fncuCofEXj2RC8bLP5aHD43yNaKLD0hLQycvqnStcUZ/M4Wq6OJLTpCCFBhRhJbyrPCUkfwdzi1+kXQanlpiWwpy+I3Jy5YGkff8CTtA2NaP1BRTxPCAty2vojjnS46BsdCep/jHS4S4xysKozeM5QD9Ya1hdR3uLjgnrAsBv/uWU0IKtppQliA22q8m6d/cvB8SO9T3+Fi/bIM4p367bl1bSHgnTayyr6WfpLiHaxfFtsjNhX99BVnASpyU7lzYzH//uKZkL1jnfUYGrpcbIyhltdXs6owjdLsZH7TbM20kcdjeLKhh5tXFcTsii8VOzQhLNCf3baGWY/ha0+fDMn1W/tGGJuaZWOM1w/8RIRb1xayt6V/UadqLdWRc4P0Dk9y+4Z5W2spFVU0ISxQWU4KH9xZwU8Pd9DcHfzlkPUd3jOUNSH8jzesLWBi2sM+CzapPdHQQ4LTwZ41BWG/t1LhpglhET52y0oyk+P58uPNQe9vVN8xRFpiHNV5egCL3/aqXNIS43imObx1BGO800U3rMzT/kUqJmhCWITMlHg+sWclL57u57engnsmw7EOFzUlGZbvzLWThDgHN67K49kTF8LaYPB4p4vOofFLiwmUinaaEBbpfddXUJmbwpcfb77Ub2WpXGPTNHW52KIHsLzOG9YUcsE9SUNn+HYtP368hziH8MZ1hWG7p1JW0oSwSAlxDj57+xpOXRjhp4c7gnLNpxp7mJ413K7vSF/nljUFOASeCdNqI+90UTc7lueSlaIHsajYoAlhCd68voi6imy+9vQpRiZnlny9x+q7KM9JidmW11eTk5pAbXl22HYtn+gZ5uzAGLfXFIflfkrZgSaEJRAR/vzOdQyMTvI3/920pGsNjEyyv3WAOzcWa7+cK3jD2kIaOt30uEK/a/mJhh4cAm9ar9NFKnZoQliizWVZfPTG5Tx84DzPNC3+3euTjT3Megx3blwWxOiiy61rvUs/wzFKeOJ4N9sqc/RkLhVTNCEEwR+/cSVritL57KP1DMxz0lMg/utYN9X5qawt1v5FV7KiII3ynBR+E+Llpy29I5zuHeGODTpdpGKLJoQgSIxz8vX3bsY9PsPnHj2+4KWRve4JXj4zwJ0bl+l00VWICG9YW8C+ln5c49Mhu8+TDd2At0akVCzRhBAka4oy+NM3r+bppgsLXnX0+PFujIG3btR3pNfyztpSJmc8IW0w+ERDD7XlWRRl6lGNKrbYJiGIyMdF5ISINIrI31sdz2J8ZHcV26ty+OKvGjl/MfAW2f9V383qwnRWarvra6opyWR7VQ7f2382aPs/5mofGKWxy62ri1RMskVCEJFbgLuATcaY9cA/WBzSojgcwtfeswkR4U9+cjSgF6yuoXEOtQ9yp44OAvaR3VV0Do3zVGPwi8vf2XuGOIdwh34/VAyyRUIA/hD4ijFmEsAYY13z+yUqzU7hS29fz8Gzg/ztEyeu+fjHj3vnq+/cpKuLAvWGtYWU56Tw4L4zQb3u+YtjPHzgHO/ZVkaJnt2rYpBdEsIq4AYReUVEfisi2670QBG5X0QOicihvr7g9hEKlt/ZUsp9Oyv5zt4z/Owa9YTH6rupKcmgKi81TNFFPqdD+NCuSg63D3L0/FDQrvuN35xGRPjEnpVBu6ZSkSRsCUFEnhGRhnk+7gLigBzgeuBPgZ/IFZbbGGMeMMbUGWPq8vPzwxX+gn3hLWvZUZ3L539+nFd9RzBe7vzFMY6dH9K9B4vw7roy0hPjeHBvcEYJLb3DPHqkgw9cX6HFZBWzwpYQjDG3GmNq5vn4JdABPGq8DgAeIC9csYVCvNPBt+6tpTAjkY8+dHjeE9Z+dawLgLfoevcFS0uM4+5tZTx+vJtu1/iSr/ePvz5FcryTP7x5eRCiUyoy2WXK6BfALQAisgpIAMJ/GkqQZacm8O8fqGNkcoaPPnSYielZzl8c499+28pd39zLV586ybbKbMpyUqwONSJ9cGclHmP4wUvtS7pOQ6eLx4/38JEbqsnVnckqhsVZHYDPg8CDItIATAEfNOFsfB9Ca4oy+Mf3bOIPfniEG//+OXqHvTuZN5Rk8me3reHddaUWRxi5ynJSePP6Iv7jlXN8fM8KUhIW9+P8D0+fJDM5nt+7oSrIESoVWWyREIwxU8D7rI4jVG6rKebzd6zhqcYLfHh3FXfUFFOeq6OCYPjw7iqeaOjh0SOdvO/6igV//sGzF3n+ZB+fvX0NGXoqmopxtkgIseD+G5dz/406Px1sdRXZbCzN5FvPtfCmdYUUZAReEDbG8NWnTpKfnsgHd1SGLkilIoRdaghKLYqI8KW7ahgan+b93znA0NhUQJ/n8Ri++FgTB85c5BN7VpCc4AxxpErZnyYEFfE2lWXx7Q/UcWZglPu+e5DRaxxWND3r4VM/Pcb39p/l93ZXce/2hU81KRWNNCGoqLBzRR7fvGcLxztd3P/QISamZ+d93MT0LH/4w8P8/NVOPv2mVXzhLWtxOLTDrFKgCUFFkTetL+Lv37mRfS0DfOLhV1/XS2p4YpoPPniA35zo5Utvr+Fje1Zqu3Gl5tCisooq79xayvDENP/nsSau/9tnSYp34BDB6RCGJ6YZGpvm63dv5q7NJVaHqpTtaEJQUee+XVWkJcXzctsAHmPweAyzxruq6O5tZdyw0r4tT5SykiYEFZXetbWUd23VTX9KLYTWEJRSSgGaEJRSSvloQlBKKQVoQlBKKeWjCUEppRSgCUEppZSPJgSllFKAJgSllFI+EskHk4lIH7C08xNfK4/IP7pTn4M9RMNzgOh4HvocXq/CGPO6LfsRnRCCTUQOGWPqrI5jKfQ52EM0PAeIjuehzyFwOmWklFIK0ISglFLKRxPCaz1gdQBBoM/BHqLhOUB0PA99DgHSGoJSSilARwhKKaV8NCEopZQCNCG8joh8SUTqReSoiDwtIsusjmmhROSrInLC9zx+LiJZVse0UCLybhFpFBGPiETUkkERuU1ETopIi4h81up4FkpEHhSRXhFpsDqWxRKRMhF5TkSafD9Hn7Q6psUQkSQROSAix3zP44shvZ/WEF5LRDKMMW7f/38CWGeM+QOLw1oQEXkT8KwxZkZE/g7AGPNnFoe1ICKyFvAA/wZ82hhzyOKQAiIiTuAU8EagAzgI3GOMabI0sAUQkRuBEeAHxpgaq+NZDBEpBoqNMUdEJB04DLw9kr4PACIiQKoxZkRE4oG9wCeNMS+H4n46QriMPxn4pAIRlzGNMU8bY2Z8f3wZiLizJI0xzcaYk1bHsQjXAS3GmDZjzBTwY+Aui2NaEGPMC8BFq+NYCmNMtzHmiO//h4FmoMTaqBbOeI34/hjv+wjZa5ImhHmIyN+IyHngXuAvrY5niT4MPGF1EDGkBDg/588dROALUTQRkUpgC/CKtZEsjog4ReQo0Av82hgTsucRkwlBRJ4RkYZ5Pu4CMMZ8wRhTBvwI+Ji10c7vWs/B95gvADN4n4ftBPIclFoKEUkDHgH+6LLRf8QwxswaYzbjHelfJyIhm8aLC9WF7cwYc2uAD/0R8DjwVyEMZ1Gu9RxE5D7gTuANxqaFogV8HyJJJ1A258+lvr9TYeabc38E+JEx5lGr41kqY8yQiDwH3AaEpOAfkyOEqxGRlXP+eBdwwqpYFktEbgM+A7zNGDNmdTwx5iCwUkSqRCQBeC/wK4tjijm+Yux3gGZjzD9aHc9iiUi+f5WgiCTjXawQstckXWV0GRF5BFiNd4VLO/AHxpiIeocnIi1AIjDg+6uXI3Cl1O8A/wzkA0PAUWPMm62NKjAicgfwdcAJPGiM+RuLQ1oQEXkYuBlvy+ULwF8ZY75jaVALJCK7gReB43h/lwE+b4x53LqoFk5ENgLfx/uz5AB+Yoz565DdTxOCUkop0CkjpZRSPpoQlFJKAZoQlFJK+WhCUEopBWhCUEop5aMJQSmlFKAJQSmllI8mBBVRRGTWd1ZFo69H/KdExOH7t/2+/1YupZe/iPwfEfn0Ij5v5Cr/9nYRMSKyZrFxBXKfAD73Jt9ZB7MickZEPrXUeFT00ISgIs24MWazMWY93m38t+PrNWWM2RnKG4vXYn9n7sHby/6eIIa0GEXAT4FcY0yVMeZrFsejbEQTgopYxphe4H7gY74X67nvnJ0i8u++kcTTvj4wiMj7fCdQHRWRf/MdaIOIfEFETonIXrytS/D9faXv9LMf4G0oViYivxCRw75r33+tOH0dN3cDH8Hb22jutZuvEOdf+O67V0Qenm/EcqXncg0fAJ4BXAE8VsUYTQgqohlj2vD2eSm47J9WAv/iG0kMAe/0ncJ2N7DL1054FrhXRLbifaHeDNwBbJvnWt8yxqw3xrQDHzbGbAXqgE+ISO41wrwLeNIYcwoY8N3vanFuA94JbMI7AnrdEaJXei7XiAO8/aEeAoZE5HcDeLyKITHZ/lrFhDPGmKO+/z8MVAJZwFbgoLcZJsl4Dx3JAX7u7wwrIpd3J22/7MjCT/ia74G31fVK/qeR4HzuAb7h+/8f+/58+Cpx5gG/NMZMABMi8tg813zDFZ7LFfnqF38PvBV43q5t0ZV1NCGoiCYi1XjfHV/+Yjg55/9n8b5gCvB9Y8znLrvGH13jNqNzHnszcCuwwxgzJiLPA0lXiS8H2ANsEBGDdzRjRORPrxJnIOZ9LtfwUeAfjTHPLeBzVAzRKSMVsUQkH/hX4JsBvtv9DfAuESnwfX6OiFQALwBvF5Fk8R7I/tarXCMTGPQlgzXA9de457uAh4wxFcaYSt9JfGeAG67yOfuAt4pIkq/+cOcCngsi8hsRme/YziS8RWWl5qUJQUWaZP+yU7zF0aeBLwbyicaYJuDPgadFpB74NVDsO4z9P4FjeM+fPniVyzwJxIlIM/AV4OWrPBa800M/v+zvHuEqq42MMQfxHqpT74vnOJcVga/0XHyroFYAF+e59FeBN4r3mNJfi0jxNWJXMUbPQ1DKhkQkzRgzIiIpeEcw9/sS17U+rwZv0ftPrvG47+M9bOW/gxOxigZaQ1DKnh4QkXV4p3m+H0gyADDGNADXSgZ3Aql4R1hKXaIjBKWUUoDWEJRSSvloQlBKKQVoQlBKKeWjCUEppRSgCUEppZSPJgSllFKAJgSllFI+/w91OmWpfwAG9wAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "3eTbKklCnyd_"
+      },
+      "outputs": [],
+      "source": [
+        "%%bash\n",
+        "\n",
+        "BASE_URL=\"https://drive.google.com/u/0/uc?id=1hsKkKtdxZTVfHKgqVF6qV2e-4SShmhr7&export=download\"\n",
+        "wget -q --load-cookies /tmp/cookies.txt \"$BASE_URL&confirm=$(wget -q --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate $BASE_URL -O- | sed -rn 's/.*confirm=(\\w+).*/\\1\\n/p')\" -O pysages-env.zip\n",
+        "rm -rf /tmp/cookies.txt"
       ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "KRPmkpd9n_NG",
+        "outputId": "286f58ca-9085-4d70-c151-acb90007cc30"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "env: PYSAGES_ENV=/env/pysages\n"
+          ]
+        }
+      ],
+      "source": [
+        "%env PYSAGES_ENV=/env/pysages"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "J7OY5K9VoBBh"
+      },
+      "outputs": [],
+      "source": [
+        "%%bash\n",
+        "\n",
+        "mkdir -p $PYSAGES_ENV .\n",
+        "unzip -qquo pysages-env.zip -d $PYSAGES_ENV"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "LlVSU_-FoD4w"
+      },
+      "outputs": [],
+      "source": [
+        "!update-alternatives --auto libcudnn &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "EMAWp8VloIk4"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "\n",
+        "ver = sys.version_info\n",
+        "sys.path.append(os.environ[\"PYSAGES_ENV\"] + \"/lib/python\" + str(ver.major) + \".\" + str(ver.minor) + \"/site-packages/\")\n",
+        "\n",
+        "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_strict_conv_algorithm_picker=false\"\n",
+        "os.environ[\"LD_LIBRARY_PATH\"] = \"/usr/lib/x86_64-linux-gnu:\" + os.environ[\"LD_LIBRARY_PATH\"]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "we_mTkFioS6R"
+      },
+      "source": [
+        "## PySAGES\n",
+        "\n",
+        "The next step is to install PySAGES.\n",
+        "First, we install the jaxlib version that matches the CUDA installation of this Colab setup. See the JAX documentation [here](https://github.com/google/jax) for more details."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "vK0RZtbroQWe",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "23a64d4f-d270-40aa-8f16-6da6ef43cd0b"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%bash\n",
+        "\n",
+        "pip install -q --upgrade pip\n",
+        "# Installs the wheel compatible with CUDA 11 and cuDNN 8.0.5.\n",
+        "pip install -q --upgrade \"jax[cuda11_cudnn805]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wAtjM-IroYX8"
+      },
+      "source": [
+        "Now we can finally install PySAGES. We clone the newest version from [here](https://github.com/SSAGESLabs/PySAGES) and build the remaining pure python dependencies and PySAGES itself."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "B-HB9CzioV5j"
+      },
+      "outputs": [],
+      "source": [
+        "%%bash\n",
+        "\n",
+        "rm -rf PySAGES\n",
+        "git clone https://github.com/SSAGESLabs/PySAGES.git &> /dev/null\n",
+        "cd PySAGES\n",
+        "pip install -q . &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "ppTzMmyyobHB",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "8eeee74c-53ae-4f6f-e280-51c729e7f395"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "mkdir: cannot create directory ‘/content/funn’: File exists\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%bash\n",
+        "\n",
+        "mkdir /content/funn\n",
+        "cd /content/funn"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KBFVcG1FoeMq"
+      },
+      "source": [
+        "# FUNN-biased simulations"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0W2ukJuuojAl"
+      },
+      "source": [
+        "FUNN gradually learns the free energy gradient from a discrete estimate based on the same algorithm as the ABF method, but employs a neural network to provide a continuous approximation to it.\n",
+        "\n",
+        "For this Colab, we are using butane as the example molecule."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "BBvC7Spoog82"
+      },
+      "outputs": [],
+      "source": [
+        "import hoomd\n",
+        "import hoomd.md\n",
+        "\n",
+        "import numpy\n",
+        "\n",
+        "\n",
+        "pi = numpy.pi\n",
+        "kT = 0.596161\n",
+        "dt = 0.02045\n",
+        "mode = \"--mode=gpu\"\n",
+        "\n",
+        "\n",
+        "def generate_context(kT = kT, dt = dt, mode = mode):\n",
+        "    \"\"\"\n",
+        "    Generates a simulation context, we pass this function to the attribute\n",
+        "    `run` of our sampling method.\n",
+        "    \"\"\"\n",
+        "    hoomd.context.initialize(mode)\n",
+        "\n",
+        "    ### System Definition\n",
+        "    snapshot = hoomd.data.make_snapshot(\n",
+        "        N = 14,\n",
+        "        box = hoomd.data.boxdim(Lx = 41, Ly = 41, Lz = 41),\n",
+        "        particle_types = ['C', 'H'],\n",
+        "        bond_types = [\"CC\", \"CH\"],\n",
+        "        angle_types = [\"CCC\", \"CCH\", \"HCH\"],\n",
+        "        dihedral_types = [\"CCCC\", \"HCCC\", \"HCCH\"],\n",
+        "        pair_types = [\"CCCC\", \"HCCC\", \"HCCH\"],\n",
+        "        dtype = \"double\"\n",
+        "    )\n",
+        "\n",
+        "    snapshot.particles.typeid[0] = 0\n",
+        "    snapshot.particles.typeid[1:4] = 1\n",
+        "    snapshot.particles.typeid[4] = 0\n",
+        "    snapshot.particles.typeid[5:7] = 1\n",
+        "    snapshot.particles.typeid[7] = 0\n",
+        "    snapshot.particles.typeid[8:10] = 1\n",
+        "    snapshot.particles.typeid[10] = 0\n",
+        "    snapshot.particles.typeid[11:14] = 1\n",
+        "\n",
+        "    positions = numpy.array([\n",
+        "        [-2.990196,  0.097881,  0.000091],\n",
+        "        [-2.634894, -0.911406,  0.001002],\n",
+        "        [-2.632173,  0.601251, -0.873601],\n",
+        "        [-4.060195,  0.099327, -0.000736],\n",
+        "        [-2.476854,  0.823942,  1.257436],\n",
+        "        [-2.832157,  1.833228,  1.256526],\n",
+        "        [-2.834877,  0.320572,  2.131128],\n",
+        "        [-0.936856,  0.821861,  1.258628],\n",
+        "        [-0.578833,  1.325231,  0.384935],\n",
+        "        [-0.581553, -0.187426,  1.259538],\n",
+        "        [-0.423514,  1.547922,  2.515972],\n",
+        "        [-0.781537,  1.044552,  3.389664],\n",
+        "        [ 0.646485,  1.546476,  2.516800],\n",
+        "        [-0.778816,  2.557208,  2.515062]\n",
+        "    ])\n",
+        "\n",
+        "    reference_box_low_coords = numpy.array([-22.206855, -19.677099, -19.241968])\n",
+        "    box_low_coords = numpy.array([\n",
+        "        -snapshot.box.Lx / 2,\n",
+        "        -snapshot.box.Ly / 2,\n",
+        "        -snapshot.box.Lz / 2\n",
+        "    ])\n",
+        "    positions += (box_low_coords - reference_box_low_coords)\n",
+        "\n",
+        "    snapshot.particles.position[:] = positions[:]\n",
+        "\n",
+        "    mC = 12.00\n",
+        "    mH = 1.008\n",
+        "    snapshot.particles.mass[:] = [\n",
+        "        mC, mH, mH, mH,\n",
+        "        mC, mH, mH,\n",
+        "        mC, mH, mH,\n",
+        "        mC, mH, mH, mH\n",
+        "    ]\n",
+        "\n",
+        "    reference_charges = numpy.array([\n",
+        "        -0.180000, 0.060000, 0.060000, 0.060000,\n",
+        "        -0.120000, 0.060000, 0.060000,\n",
+        "        -0.120000, 0.060000, 0.060000,\n",
+        "        -0.180000, 0.060000, 0.060000, 0.060000]\n",
+        "    )\n",
+        "    charge_conversion = 18.22262\n",
+        "    snapshot.particles.charge[:] = charge_conversion * reference_charges[:]\n",
+        "\n",
+        "    snapshot.bonds.resize(13)\n",
+        "    snapshot.bonds.typeid[0:3] = 1\n",
+        "    snapshot.bonds.typeid[3] = 0\n",
+        "    snapshot.bonds.typeid[4:6] = 1\n",
+        "    snapshot.bonds.typeid[6] = 0\n",
+        "    snapshot.bonds.typeid[7:9] = 1\n",
+        "    snapshot.bonds.typeid[9] = 0\n",
+        "    snapshot.bonds.typeid[10:13] = 1\n",
+        "\n",
+        "    snapshot.bonds.group[:] = [\n",
+        "        [0, 2], [0, 1], [0, 3], [0, 4],\n",
+        "        [4, 5], [4, 6], [4, 7],\n",
+        "        [7, 8], [7, 9], [7, 10],\n",
+        "        [10, 11], [10, 12], [10, 13]\n",
+        "    ]\n",
+        "\n",
+        "    snapshot.angles.resize(24)\n",
+        "    snapshot.angles.typeid[0:2] = 2\n",
+        "    snapshot.angles.typeid[2] = 1\n",
+        "    snapshot.angles.typeid[3] = 2\n",
+        "    snapshot.angles.typeid[4:8] = 1\n",
+        "    snapshot.angles.typeid[8] = 0\n",
+        "    snapshot.angles.typeid[9] = 2\n",
+        "    snapshot.angles.typeid[10:14] = 1\n",
+        "    snapshot.angles.typeid[14] = 0\n",
+        "    snapshot.angles.typeid[15] = 2\n",
+        "    snapshot.angles.typeid[16:21] = 1\n",
+        "    snapshot.angles.typeid[21:24] = 2\n",
+        "\n",
+        "    snapshot.angles.group[:] = [\n",
+        "        [1, 0, 2], [2, 0, 3], [2, 0, 4],\n",
+        "        [1, 0, 3], [1, 0, 4], [3, 0, 4],\n",
+        "        [0, 4, 5], [0, 4, 6], [0, 4, 7],\n",
+        "        [5, 4, 6], [5, 4, 7], [6, 4, 7],\n",
+        "        [4, 7, 8], [4, 7, 9], [4, 7, 10],\n",
+        "        [8, 7, 9], [8, 7, 10], [9, 7, 10],\n",
+        "        [7, 10, 11], [7, 10, 12], [7, 10, 13],\n",
+        "        [11, 10, 12], [11, 10, 13], [12, 10, 13]\n",
+        "    ]\n",
+        "\n",
+        "    snapshot.dihedrals.resize(27)\n",
+        "    snapshot.dihedrals.typeid[0:2] = 2\n",
+        "    snapshot.dihedrals.typeid[2] = 1\n",
+        "    snapshot.dihedrals.typeid[3:5] = 2\n",
+        "    snapshot.dihedrals.typeid[5] = 1\n",
+        "    snapshot.dihedrals.typeid[6:8] = 2\n",
+        "    snapshot.dihedrals.typeid[8:11] = 1\n",
+        "    snapshot.dihedrals.typeid[11] = 0\n",
+        "    snapshot.dihedrals.typeid[12:14] = 2\n",
+        "    snapshot.dihedrals.typeid[14] = 1\n",
+        "    snapshot.dihedrals.typeid[15:17] = 2\n",
+        "    snapshot.dihedrals.typeid[17:21] = 1\n",
+        "    snapshot.dihedrals.typeid[21:27] = 2\n",
+        "\n",
+        "    snapshot.dihedrals.group[:] = [\n",
+        "        [2, 0, 4, 5], [2, 0, 4, 6], [2, 0, 4, 7],\n",
+        "        [1, 0, 4, 5], [1, 0, 4, 6], [1, 0, 4, 7],\n",
+        "        [3, 0, 4, 5], [3, 0, 4, 6], [3, 0, 4, 7],\n",
+        "        [0, 4, 7, 8], [0, 4, 7, 9], [0, 4, 7, 10],\n",
+        "        [5, 4, 7, 8], [5, 4, 7, 9], [5, 4, 7, 10],\n",
+        "        [6, 4, 7, 8], [6, 4, 7, 9], [6, 4, 7, 10],\n",
+        "        [4, 7, 10, 11], [4, 7, 10, 12], [4, 7, 10, 13],\n",
+        "        [8, 7, 10, 11], [8, 7, 10, 12], [8, 7, 10, 13],\n",
+        "        [9, 7, 10, 11], [9, 7, 10, 12], [9, 7, 10, 13]\n",
+        "    ]\n",
+        "\n",
+        "    snapshot.pairs.resize(27)\n",
+        "    snapshot.pairs.typeid[0:1] = 0\n",
+        "    snapshot.pairs.typeid[1:11] = 1\n",
+        "    snapshot.pairs.typeid[11:27] = 2\n",
+        "    snapshot.pairs.group[:] = [\n",
+        "        # CCCC\n",
+        "        [0, 10],\n",
+        "        # HCCC\n",
+        "        [0, 8], [0, 9], [5, 10], [6, 10],\n",
+        "        [1, 7], [2, 7], [3, 7],\n",
+        "        [11, 4], [12, 4], [13, 4],\n",
+        "        # HCCH\n",
+        "        [1, 5], [1, 6], [2, 5], [2, 6], [3, 5], [3, 6],\n",
+        "        [5, 8], [6, 8], [5, 9], [6, 9],\n",
+        "        [8, 11], [8, 12], [8, 13], [9, 11], [9, 12], [9, 13]\n",
+        "    ]\n",
+        "\n",
+        "    hoomd.init.read_snapshot(snapshot)\n",
+        "\n",
+        "    ### Set interactions\n",
+        "    nl_ex = hoomd.md.nlist.cell()\n",
+        "    nl_ex.reset_exclusions(exclusions = [\"1-2\", \"1-3\", \"1-4\"])\n",
+        "\n",
+        "    lj = hoomd.md.pair.lj(r_cut = 12.0, nlist = nl_ex)\n",
+        "    lj.pair_coeff.set('C', 'C', epsilon = 0.07, sigma = 3.55)\n",
+        "    lj.pair_coeff.set('H', 'H', epsilon = 0.03, sigma = 2.42)\n",
+        "    lj.pair_coeff.set('C', 'H', epsilon = numpy.sqrt(0.07*0.03), sigma = numpy.sqrt(3.55*2.42))\n",
+        "\n",
+        "    coulomb = hoomd.md.charge.pppm(hoomd.group.charged(), nlist = nl_ex)\n",
+        "    coulomb.set_params(Nx = 64, Ny = 64, Nz = 64, order = 6, rcut = 12.0)\n",
+        "\n",
+        "    harmonic = hoomd.md.bond.harmonic()\n",
+        "    harmonic.bond_coeff.set(\"CC\", k = 2*268.0, r0 = 1.529)\n",
+        "    harmonic.bond_coeff.set(\"CH\", k = 2*340.0, r0 = 1.09)\n",
+        "\n",
+        "    angle = hoomd.md.angle.harmonic()\n",
+        "    angle.angle_coeff.set(\"CCC\", k = 2*58.35, t0 = 112.7 * pi / 180)\n",
+        "    angle.angle_coeff.set(\"CCH\", k = 2*37.5, t0 = 110.7 * pi / 180)\n",
+        "    angle.angle_coeff.set(\"HCH\", k = 2*33.0, t0 = 107.8 * pi / 180)\n",
+        "\n",
+        "\n",
+        "    dihedral = hoomd.md.dihedral.opls()\n",
+        "    dihedral.dihedral_coeff.set(\"CCCC\", k1 = 1.3, k2 = -0.05, k3 = 0.2, k4 = 0.0)\n",
+        "    dihedral.dihedral_coeff.set(\"HCCC\", k1 = 0.0, k2 = 0.0, k3 = 0.3, k4 = 0.0)\n",
+        "    dihedral.dihedral_coeff.set(\"HCCH\", k1 = 0.0, k2 = 0.0, k3 = 0.3, k4 = 0.0)\n",
+        "\n",
+        "    lj_special_pairs = hoomd.md.special_pair.lj()\n",
+        "    lj_special_pairs.pair_coeff.set(\"CCCC\", epsilon = 0.07, sigma = 3.55, r_cut = 12.0)\n",
+        "    lj_special_pairs.pair_coeff.set(\"HCCH\", epsilon = 0.03, sigma = 2.42, r_cut = 12.0)\n",
+        "    lj_special_pairs.pair_coeff.set(\"HCCC\",\n",
+        "        epsilon = numpy.sqrt(0.07 * 0.03), sigma = numpy.sqrt(3.55 * 2.42), r_cut = 12.0\n",
+        "    )\n",
+        "\n",
+        "    coulomb_special_pairs = hoomd.md.special_pair.coulomb()\n",
+        "    coulomb_special_pairs.pair_coeff.set(\"CCCC\", alpha = 0.5, r_cut = 12.0)\n",
+        "    coulomb_special_pairs.pair_coeff.set(\"HCCC\", alpha = 0.5, r_cut = 12.0)\n",
+        "    coulomb_special_pairs.pair_coeff.set(\"HCCH\", alpha = 0.5, r_cut = 12.0)\n",
+        "\n",
+        "    hoomd.md.integrate.mode_standard(dt = dt)\n",
+        "    integrator = hoomd.md.integrate.nvt(group = hoomd.group.all(), kT = kT, tau = 100*dt)\n",
+        "    integrator.randomize_velocities(seed = 42)\n",
+        "\n",
+        "    return hoomd.context.current"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3UrzENm_oo6U"
+      },
+      "source": [
+        "Next, we load PySAGES and the relevant classes and methods for our problem"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "fpMg-o8WomAA"
+      },
+      "outputs": [],
+      "source": [
+        "from pysages.grids import Grid\n",
+        "from pysages.colvars import DihedralAngle\n",
+        "from pysages.methods import FUNN\n",
+        "\n",
+        "import pysages"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LknkRvo1o4av"
+      },
+      "source": [
+        "The next step is to define the collective variable (CV). In this case, we choose the central dihedral angle.\n",
+        "\n",
+        "We also define a grid to bin our CV space, the topology (tuple indicating the number of\n",
+        "nodes of each hidden layer) for our neural network which will model the free energy.\n",
+        "\n",
+        "The appropriate number of bins depends on the complexity of the free energy landscape,\n",
+        "a good rule of thumb is to choose between 20 to 100 bins along each CV dimension\n",
+        "(using higher values for more rugged free energy surfaces), but it can be systematically\n",
+        "found trying different values for short runs of any given system."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "id": "B1Z8FWz0o7u_"
+      },
+      "outputs": [],
+      "source": [
+        "cvs = [DihedralAngle([0, 4, 7, 10])]\n",
+        "grid = Grid(lower=(-pi,), upper=(pi,), shape=(64,), periodic=True)\n",
+        "\n",
+        "topology = (14,)\n",
+        "method = FUNN(cvs, grid, topology)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Fz8BfU34pA_N"
+      },
+      "source": [
+        "We now simulate $5\\times10^5$ time steps.\n",
+        "Make sure to run with GPU support, otherwise, it can take a very long time."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "K951m4BbpUar",
+        "outputId": "0e9eb82c-21cf-4048-a83d-ad246dc05ebe"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "HOOMD-blue v2.9.7 CUDA (11.1) DOUBLE HPMC_MIXED SSE SSE2 \n",
+            "Compiled: 07/07/2022\n",
+            "Copyright (c) 2009-2019 The Regents of the University of Michigan.\n",
+            "-----\n",
+            "You are using HOOMD-blue. Please cite the following:\n",
+            "* J A Anderson, J Glaser, and S C Glotzer. \"HOOMD-blue: A Python package for\n",
+            "  high-performance molecular dynamics and hard particle Monte Carlo\n",
+            "  simulations\", Computational Materials Science 173 (2020) 109363\n",
+            "-----\n",
+            "HOOMD-blue is running on the following GPU(s):\n",
+            " [0]              Tesla T4  40 SM_7.5 @ 1.59 GHz, 15109 MiB DRAM, MNG\n",
+            "notice(2): Group \"all\" created containing 14 particles\n",
+            "notice(2): -- Neighborlist exclusion statistics -- :\n",
+            "notice(2): Particles with 7 exclusions             : 6\n",
+            "notice(2): Particles with 10 exclusions             : 6\n",
+            "notice(2): Particles with 13 exclusions             : 2\n",
+            "notice(2): Neighbors included by diameter          : no\n",
+            "notice(2): Neighbors excluded when in the same body: no\n",
+            "notice(2): Group \"charged\" created containing 14 particles\n",
+            "-----\n",
+            "You are using PPPM. Please cite the following:\n",
+            "* D N LeBard, B G Levine, S A Barr, A Jusufi, S Sanders, M L Klein, and A Z\n",
+            "  Panagiotopoulos. \"Self-assembly of coarse-grained ionic surfactants\n",
+            "  accelerated by graphics processing units\", Journal of Computational Physics 8\n",
+            "  (2012) 2385-2397\n",
+            "-----\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pysages/ml/utils.py:54: FutureWarning: jax.tree_flatten is deprecated, and will be removed in a future release. Use jax.tree_util.tree_flatten instead.\n",
+            "  data, structure = tree_flatten(params)\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "** starting run **\n",
+            "notice(2): charge.pppm: RMS error: 1.29239e-08\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+            "  dp = solve(H, Je, sym_pos=True)\n",
+            "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+            "  dp = solve(H, Je, sym_pos=True)\n",
+            "/usr/local/lib/python3.7/dist-packages/pysages/methods/funn.py:191: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+            "  Wp = linalg.solve(Jxi @ Jxi.T, Jxi @ p, sym_pos=\"sym\")\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Time 00:00:15 | Step 2382 / 500000 | TPS 238.192 | ETA 00:34:49\n",
+            "Time 00:00:25 | Step 9800 / 500000 | TPS 741.731 | ETA 00:11:00\n",
+            "Time 00:00:35 | Step 16594 / 500000 | TPS 679.375 | ETA 00:11:51\n",
+            "Time 00:00:45 | Step 23699 / 500000 | TPS 710.482 | ETA 00:11:10\n",
+            "Time 00:00:55 | Step 30685 / 500000 | TPS 698.565 | ETA 00:11:11\n",
+            "Time 00:01:05 | Step 38038 / 500000 | TPS 735.282 | ETA 00:10:28\n",
+            "Time 00:01:15 | Step 44802 / 500000 | TPS 676.339 | ETA 00:11:13\n",
+            "Time 00:01:25 | Step 51935 / 500000 | TPS 713.242 | ETA 00:10:28\n",
+            "Time 00:01:35 | Step 59345 / 500000 | TPS 740.912 | ETA 00:09:54\n",
+            "Time 00:01:45 | Step 66486 / 500000 | TPS 714.031 | ETA 00:10:07\n",
+            "Time 00:01:55 | Step 73877 / 500000 | TPS 739.073 | ETA 00:09:36\n",
+            "Time 00:02:05 | Step 81221 / 500000 | TPS 734.045 | ETA 00:09:30\n",
+            "Time 00:02:15 | Step 88551 / 500000 | TPS 732.972 | ETA 00:09:21\n",
+            "Time 00:02:25 | Step 95662 / 500000 | TPS 711.075 | ETA 00:09:28\n",
+            "Time 00:02:35 | Step 102927 / 500000 | TPS 726.454 | ETA 00:09:06\n",
+            "Time 00:02:45 | Step 110189 / 500000 | TPS 726.175 | ETA 00:08:56\n",
+            "Time 00:02:55 | Step 117219 / 500000 | TPS 702.939 | ETA 00:09:04\n",
+            "Time 00:03:05 | Step 124386 / 500000 | TPS 716.627 | ETA 00:08:44\n",
+            "Time 00:03:15 | Step 131649 / 500000 | TPS 726.238 | ETA 00:08:27\n",
+            "Time 00:03:25 | Step 138980 / 500000 | TPS 733.08 | ETA 00:08:12\n",
+            "Time 00:03:35 | Step 146259 / 500000 | TPS 727.83 | ETA 00:08:06\n",
+            "Time 00:03:45 | Step 153598 / 500000 | TPS 733.834 | ETA 00:07:52\n",
+            "Time 00:03:55 | Step 160870 / 500000 | TPS 727.165 | ETA 00:07:46\n",
+            "Time 00:04:05 | Step 168150 / 500000 | TPS 727.977 | ETA 00:07:35\n",
+            "Time 00:04:15 | Step 175412 / 500000 | TPS 726.142 | ETA 00:07:27\n",
+            "Time 00:04:25 | Step 182753 / 500000 | TPS 734.066 | ETA 00:07:12\n",
+            "Time 00:04:35 | Step 190001 / 500000 | TPS 721.559 | ETA 00:07:09\n",
+            "Time 00:04:45 | Step 197404 / 500000 | TPS 740.255 | ETA 00:06:48\n",
+            "Time 00:04:55 | Step 204713 / 500000 | TPS 730.888 | ETA 00:06:44\n",
+            "Time 00:05:05 | Step 212053 / 500000 | TPS 733.967 | ETA 00:06:32\n",
+            "Time 00:05:15 | Step 219418 / 500000 | TPS 736.472 | ETA 00:06:20\n",
+            "Time 00:05:25 | Step 226762 / 500000 | TPS 734.326 | ETA 00:06:12\n",
+            "Time 00:05:35 | Step 233828 / 500000 | TPS 706.592 | ETA 00:06:16\n",
+            "Time 00:05:45 | Step 240993 / 500000 | TPS 716.425 | ETA 00:06:01\n",
+            "Time 00:05:55 | Step 248322 / 500000 | TPS 732.826 | ETA 00:05:43\n",
+            "Time 00:06:05 | Step 255645 / 500000 | TPS 732.213 | ETA 00:05:33\n",
+            "Time 00:06:15 | Step 263035 / 500000 | TPS 738.913 | ETA 00:05:20\n",
+            "Time 00:06:25 | Step 270349 / 500000 | TPS 731.387 | ETA 00:05:13\n",
+            "Time 00:06:35 | Step 277694 / 500000 | TPS 734.447 | ETA 00:05:02\n",
+            "Time 00:06:45 | Step 285001 / 500000 | TPS 730.286 | ETA 00:04:54\n",
+            "Time 00:06:55 | Step 292333 / 500000 | TPS 733.145 | ETA 00:04:43\n",
+            "Time 00:07:05 | Step 299675 / 500000 | TPS 734.125 | ETA 00:04:32\n",
+            "Time 00:07:15 | Step 307066 / 500000 | TPS 739.064 | ETA 00:04:21\n",
+            "Time 00:07:25 | Step 314514 / 500000 | TPS 744.769 | ETA 00:04:09\n",
+            "Time 00:07:35 | Step 321962 / 500000 | TPS 744.749 | ETA 00:03:59\n",
+            "Time 00:07:45 | Step 329389 / 500000 | TPS 742.647 | ETA 00:03:49\n",
+            "Time 00:07:55 | Step 336764 / 500000 | TPS 737.498 | ETA 00:03:41\n",
+            "Time 00:08:05 | Step 344194 / 500000 | TPS 742.825 | ETA 00:03:29\n",
+            "Time 00:08:15 | Step 351001 / 500000 | TPS 680.669 | ETA 00:03:38\n",
+            "Time 00:08:25 | Step 358207 / 500000 | TPS 720.552 | ETA 00:03:16\n",
+            "Time 00:08:35 | Step 365515 / 500000 | TPS 730.713 | ETA 00:03:04\n",
+            "Time 00:08:45 | Step 372786 / 500000 | TPS 727.084 | ETA 00:02:54\n",
+            "Time 00:08:55 | Step 380039 / 500000 | TPS 725.232 | ETA 00:02:45\n",
+            "Time 00:09:05 | Step 387469 / 500000 | TPS 742.9 | ETA 00:02:31\n",
+            "Time 00:09:15 | Step 394910 / 500000 | TPS 744.028 | ETA 00:02:21\n",
+            "Time 00:09:25 | Step 402050 / 500000 | TPS 713.989 | ETA 00:02:17\n",
+            "Time 00:09:35 | Step 409480 / 500000 | TPS 742.954 | ETA 00:02:01\n",
+            "Time 00:09:45 | Step 416909 / 500000 | TPS 742.893 | ETA 00:01:51\n",
+            "Time 00:09:55 | Step 424338 / 500000 | TPS 742.894 | ETA 00:01:41\n",
+            "Time 00:10:05 | Step 431758 / 500000 | TPS 741.955 | ETA 00:01:31\n",
+            "Time 00:10:15 | Step 439226 / 500000 | TPS 746.72 | ETA 00:01:21\n",
+            "Time 00:10:25 | Step 446648 / 500000 | TPS 742.13 | ETA 00:01:11\n",
+            "Time 00:10:35 | Step 454097 / 500000 | TPS 744.802 | ETA 00:01:01\n",
+            "Time 00:10:45 | Step 461493 / 500000 | TPS 739.54 | ETA 00:00:52\n",
+            "Time 00:10:55 | Step 468989 / 500000 | TPS 749.58 | ETA 00:00:41\n",
+            "Time 00:11:05 | Step 476190 / 500000 | TPS 720.017 | ETA 00:00:33\n",
+            "Time 00:11:15 | Step 483637 / 500000 | TPS 744.693 | ETA 00:00:21\n",
+            "Time 00:11:25 | Step 491091 / 500000 | TPS 745.319 | ETA 00:00:11\n",
+            "Time 00:11:35 | Step 498561 / 500000 | TPS 746.975 | ETA 00:00:01\n",
+            "Time 00:11:37 | Step 500000 / 500000 | TPS 742.668 | ETA 00:00:00\n",
+            "Average TPS: 722.503\n",
+            "---------\n",
+            "-- Neighborlist stats:\n",
+            "82696 normal updates / 1667 forced updates / 0 dangerous updates\n",
+            "n_neigh_min: 0 / n_neigh_max: 6 / n_neigh_avg: 3.85714\n",
+            "shortest rebuild period: 3\n",
+            "-- Cell list stats:\n",
+            "Dimension: 3, 3, 3\n",
+            "n_min    : 0 / n_max: 14 / n_avg: 0.518519\n",
+            "** run complete **\n"
+          ]
+        }
+      ],
+      "source": [
+        "run_result = pysages.run(method, generate_context, int(5e5))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PXBKUfK0p9T2"
+      },
+      "source": [
+        "Since the neural network learns the gradient of the free energy, we need a separate way of integrating it to find the free energy surface. Let's plot first the gradient of the free energy."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "id": "X69d1R7OpW4P"
+      },
+      "outputs": [],
+      "source": [
+        "import matplotlib.pyplot as plt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "result = pysages.analyze(run_result)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "55W8QRe7h666",
+        "outputId": "690a8583-f7e8-47ab-adfb-52afd179160d"
+      },
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pysages/ml/utils.py:54: FutureWarning: jax.tree_flatten is deprecated, and will be removed in a future release. Use jax.tree_util.tree_flatten instead.\n",
+            "  data, structure = tree_flatten(params)\n",
+            "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+            "  dp = solve(H, Je, sym_pos=True)\n",
+            "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+            "  dp = solve(H, Je, sym_pos=True)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "mesh = result[\"mesh\"]\n",
+        "A = result[\"free_energy\"]"
+      ],
+      "metadata": {
+        "id": "QZObNpLTh9JY"
+      },
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 303
+        },
+        "id": "TBiPAnMwqEIF",
+        "outputId": "6ae55c65-5f08-42a5-d48e-11772b318f96"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<matplotlib.axes._subplots.AxesSubplot at 0x7f07042f45d0>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 16
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEMCAYAAADHxQ0LAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3xcd5Xw/88ZdcuSbfXiIlly77biHsd24lTHDiRAQkJdSHgCAXZhgV1gl4Vll11+LGR5gBAIhBQSAunNaU5xj+Uud1u2rGoVW9Xqc35/zCiPMS6SNTN3ynm/Xn5ZZXS/Z2Tr6M65556vqCrGGGPCn8vpAIwxxgSGJXxjjIkQlvCNMSZCWMI3xpgIYQnfGGMihCV8Y4yJEAFL+CIyQUR2nvWnWUS+Gqj1jTEm0okTffgiEgVUAvNUtexCj0tLS9O8vLyAxWWMMaFu27Zt9aqafr7PRQc6GK+rgaMXS/YAeXl5FBcXBygkY4wJfSJywbzqVA3/duCJ831CRO4WkWIRKa6rqwtwWMYYE74CnvBFJBZYBfz5fJ9X1QdVtUhVi9LTz/uqxBhjzGVw4gz/BmC7qp50YG1jjIlYTiT8O7hAOccYY4z/BDThi0gisAJ4JpDrGmOMCXCXjqq2AamBXNMYY4yH3WlrjDERwqk+fGNCUmdPL5Wn26k43U756TOowseuGEVMlJ07meBnCd+Yfjh8soV7Ht1GaX3b33xuc2kD998+iyiXOBCZMf1nCd+YS2jp6OaeR7fR3NHN318znpEjEhiVMoSRIxJ4cVcV//nqARJjo/nRrdMQsaRvgpclfGMuQlX5+p93UXbqDI9/bh7zx/51z8E9VxXQ1tnD/649QmJcNN9dOcmSvglalvCNuYgH3i3ltb0n+c5Nk/4m2ff5+xXjaens4XcbjpEUH83frxgf4CiN6R9L+MZcwIYj9fz4tQOsnJ7N3y3Ov+DjRITv3jSZts4e7n/rMEnx0XzuyrEBjNSY/rHWAmPOo7Kxnfue2EFB+lD+69bplyzTuFzCf354OjdMzeI/XtnPiYYzAYrUmP6zhG/MOdxu5d7Ht9PV4+aBT8whMa5/L4SjXML3Vk0hyiX8dn2pn6M0ZuAs4RtzjrUHatlV3sj3Vk2hIH3ogL42MzmeD83K5anichpaO/0UoTGXxxK+Mef4/cZjZCXHs3pmzmV9/d1LxtLR7eaRTRfd38eYgLOEb8xZDta0sOFIA59cOOay754tzEjimkmZPLLpOGe6enwboDGDYAnfmLP8fsMx4mNc3HHF6EEd5wtXjeX0mW6e2lruo8iMGTxL+MZ4nWrr4tkdlXxo1khGJMYO6lhFeSkUjRnBb9Ydo6fX7aMIjRkcS/jGeD3x/gk6e9x8ZlGeT453z1UFVDa28/Keap8cz5jBsoRvDNDd6+aRTce5clwa4zOTfHLMqydmUJCeyK/fLUVVfXJMYwbDEr4xwCt7qjnZ3Omzs3vw3Ix1z5IC9lU3s/5Ivc+Oa8zlsoRvDPD7DcfJT0tk6fgMnx539awcMpLi+M26Yz49rjGXwxK+iXjbT5xmZ3kjn16Yh8vHM+3joqP4SNFINhyp51Rbl0+PbcxAWcI3Ee/3G46TFBfNrXNG+uX4N0zNptetvLGvxi/HN6a/LOGbiNba2cNre2v48OxchvZzZs5ATclJZuSIBNaUWMI3zgpowheR4SLyFxE5ICL7RWRBINc35lzvHKylq8fNjdOy/baGiHDD1CzWH6mnuaPbb+sYcymBPsO/H1ijqhOBGcD+AK9vzF9ZU1JD2tBYivJS/LrO9VOz6e5V1u6v9es6xlxMwBK+iAwDlgAPAahql6o2Bmp9Y87V0d3L2wdqWTE5y+8bkM8aNZzM5DheLbGbsIxzAnmGnw/UAb8XkR0i8lsRSTz3QSJyt4gUi0hxXV1dAMMzkWb94Xraunq5fmqW39dyuYTrpmTx7qE6G6hmHBPIhB8NzAZ+paqzgDbgW+c+SFUfVNUiVS1KT08PYHgm0qzZW0NSfDQLLrBXra9dPzWLjm437x60ExnjjEAm/AqgQlW3eN//C55fAMYEXHevmzf2nWTFpExiowPzYzA3L4WUxFhetW4d45CAJXxVrQHKRWSC90NXA/sCtb4xZ9tSeoqm9m6uC0A5p090lIsVkzJZe6CWzp7egK1rTJ9Ad+ncBzwuIruBmcB/BHh9YwBYs7eahJgolowLbNnw+mlZtHb2sP6wzdYxgeefO00uQFV3AkWBXNOYc7ndymt7T7JsYjoJsVEBXXtRQRpJ8dG8WlLD1ZMyA7q2MXanrYk420+cpq6lk+umBK6c0yc22sU1kzJ5c/9Jum1jFBNglvBNxFlTUkNslIvlE307GbO/rp+aReOZbraUnnJkfRO5LOGbiKKqrNlbw+JxaSTFxzgSw5Jx6STERLFmr92EZQLLEr6JKHurmqk43c71DpRz+iTERrGoMJV1duHWBJglfBNR1pTUEOUSrpns7AXTRYVplDWcofzUGUfjMJHFEr6JKGsP1FI0ZgQpibGOxrG4MA2ADbb1oQkgS/gmYtS1dLKvupkl450f2VGYMZSMpDjb69YElCV8EzE2HvUk1yvHpTkciWdG/uLCNDYebcDtVqfDMRHCEr6JGO8dqmfEkBim5AxzOhQAFo9L41RbF/trmp0OxUQIS/gmIqgq6w7Xsagwze+z7/trkdXxTYBZwjcR4dDJVmpbOoOinNMnMzmecRlDrT3TBIwlfBMR1h32zKBfHOBhaZeyqDCNrcdP0dFt0zON/1nCNxFh3eF6CtITyR2e4HQof2VxYRod3W62nzjtdCgmAljCN2Gvo7uXLccauDLIzu4B5o1NIcolVsc3AWEJ34S97WWn6eh2B1X9vk9SfAyzRg1n/ZEGp0MxEcASvgl77x2uJ9olzAvQ3rUDtagwjT0VjTSd6XY6FBPmLOGbsLfucB2zx4xgaFxA9/vpt8Xj0nArbCq1so7xL0v4Jqw1tHayt6qZJUFYzukzc9RwEmOjbMyC8TtL+Cas9SXRYGvHPFtMlIt5Y1PZYHV842eW8E1YW3e4nmEJMUzLDY5xCheyuDCNY/VtVJy2ccnGfwKa8EXkuIjsEZGdIlIcyLVN5FFV1h+uZ3EQjVO4kMXjbMyC8T8nzvCXqepMVS1yYG0TQY7UtlLT3PFBMg1m4zKGkjY01va5NX5lJR0Ttt7zzqjp22wkmIkIc/NT2HLMEr7xn0AnfAVeF5FtInL3+R4gIneLSLGIFNfV1QU4PBNONh1tYEzqEEalDHE6lH6Zm5dCZWO71fGN3wQ64S9W1dnADcAXRWTJuQ9Q1QdVtUhVi9LTg7ezwgS3Xrey5VgDC4L0ZqvzmZvvifV9O8s3fhLQhK+qld6/a4FngbmBXN9Ejv3VzbR09DA/hBL+xKwkkuOjLeEbvwlYwheRRBFJ6nsbuBYoCdT6JrJsLvX0tIdSwne5rI5v/CuQZ/iZwHoR2QW8D7ysqmsCuL6JIJuONpCflkjWsHinQxmQufkpHKtvo7a5w+lQTBgK2HARVS0FZgRqPRO5et3K+8dOsXJGttOhDNi8vjr+8VOsnJ7jcDQm3Fhbpgk7e6uaaOkMrfp9nyk5ySTGRlk/vvELS/gm7PTV70OpQ6dPdJSLOXkpduHW+IUlfBN2NpeeYmx6IhnJoVW/7zMvP4WDJ1s43dbldCgmzFjCN2Glp9fN+8dOhWQ5p8/c/BTAU8c3xpcs4ZuwsreqmdYQrd/3mT5yGHHRLivrGJ+zhG/CyqYP+u9THI7k8sVFRzFr9HBL+MbnLOGbsLK5tIGC9EQykkKzft9nbn4qe6uaaO6wfW6N71jCN2Gjp9fN1mOnWFAQuuWcPvPzU3ArbCs77XQoJoxYwjdhY09lE21dvSFdv+8za/QIol1iZR3jU5bwTdjY7L1Zqe9u1VCWEBvF9JHD2FJq+9wa37GEb8LG5tIGxmUMJT0pzulQfGLe2FR2VzTR3tXrdCgmTFjCN2Ghu9fN1uOh3X9/rrn5KfS4le0nrI5vfMMSvgkLeyqbOBMm9fs+c8aMwCW2IYrxHUv4Jiz0zc+ZF8L99+dKjo9hck6yJXzjM5bwTVjYXHqK8ZlDSRsaHvX7PnPzUtl+4jRdPW6nQzFhwBK+CXndvW6Kj58Ki+6cc83NT6Gzx82eykanQzFhwBK+CXnhWL/vc0XeCADeP2YXbs3gWcI3Ia9vs5Bwqt/3SR0aR2HGUN4/Zv34ZvAs4ZuQ19d/H271+z5z81MoPn6aXrc6HYoJcZbwTUjrq9+HYzmnz7z8FFo6e9hf3ex0KCbEBTzhi0iUiOwQkZcCvbYJPyVhND/nQq7I826IYu2ZZpCcOMP/CrDfgXVNGNriTYJ9u0SFo5zhCYwckcBW2wHLDFJAE76IjARuAn4byHVN+Npc2kBhGM3PuZC5+Z6NzVWtjm8uX6DP8H8GfAO44F0kInK3iBSLSHFdXV3gIjMhp2/+fSjvbtVf8/JTaGjr4mhdm9OhmBAWsIQvIiuBWlXddrHHqeqDqlqkqkXp6ekBis6EopKq5rCv3/eZ672pzOr4ZjACeYa/CFglIseBJ4HlIvJYANc3YeaD+TlheIftufJSh5CeFGf9+BfR3evm+Z2V3Pnbzfzr8yW2PeR5RAdqIVX9J+CfAERkKfB1Vb0rUOub8LPFu39tuNfvAUSEuXkpdoZ/Hk1nuvnj+yd4ZNNxqps6yB2ewKajDby29yT/fstUrpmc6XSIQcP68E1I6ul1s/X46Ygo5/SZm59CVVMHFafPOB1K0PjtulLm/+db/NeaA+SnJfLQp4pY941lPHPvIoYlxPC5R4r58hM7aGjtdDrUoBCwM/yzqeo7wDtOrG3Cw96qZlo7eyIu4YOnjj9yxBCHo3HeltIGfvjKfpaMS+eb109kck7yB5+bOWo4L963mAfePcrP1x5m3eE6Hvr0FcwePcLBiJ1nZ/gmJIXj/PtLmZCZRHJ8tJV1gJaObr72512MThnCL++c/VfJvk9stIsvXz2OV758JUNio/nmX3bT3RvZY6YHnPBFJFFEovwRjDH9tdlbv89Iinc6lIBxueSDfvxI9+8v7aeqsZ2ffGQGiXEXL1SMy0zi+6uncLi2ld9vOBagCIPTJRO+iLhE5OMi8rKI1AIHgGoR2SciPxaRQv+Hacz/09Prpvj4aeZFUDmnzxV5KZTWt1Hb0uF0KI55c99J/lRczj1XFVCU179XeFdPyuSaSRn87M3DVDe1+znC4NWfM/y3gQI8HTZZqjpKVTOAxcBm4L9ExLptTMDsrWqmJcLq9336nvPm0sg8y29o7eRbz+xmYlYSX71m3IC+9l9vnkKvW/nhy5E72aU/Cf8aVf2Bqu5W1Q8KYKp6SlWfVtVbgT/5L0Rj/tqGo/UALIjAhD8lJ5mk+Gg2eb8HkURV+fazJTS39/DTj80kLnpgleVRKUO4d2khL+2uZsORyPv+Qf+6dL4E/PRiD1BVu8PBhw7UNLPuUD1xMS7iol3ERUcRH+Ni9ugRZCRHTs36QjYeaWBiVlJE9N+fKzrKxbz8FDYdjbwbsF7YVcWavTV864aJTMr+24u0/XHPVWN5ensF//J8Ca9+ZQmx0ZHVtzKghC8it6vqk32fEJFMYDbwpiV933hr/0m++MftdHT/bTdB2tBY/vDZuUzJGeZAZMGho7uXrcdPcee8MU6H4pgFBWm8ub+WysZ2cocnOB1OQLjdyv1vHmZKTjKfv3LsZR8nPiaK762azGcfLuZ3G47xhasKfBhl8OvPr7fRIpLkfftX53zuEeBjwOM+jSpCPbW1nLsf3cb4zCTWf3MZ275zDRu/tZy3v76UP909n9goF7c/uJniCB6Tu73sNJ09bhYVRl45p8/CAs9zj6Sz/LUHaimtb+PuJWOJcsmgjrV8YiYrJmfyv28d5mRzZF387k/CPwX8h4isBqJFZMlZn8tW1U8Df/BHcJFCVfn5W4f5xtO7WVSYxhOfn8/IEUNIHRpHzvAE8tMSmTc2lT//n4WkD43jroe28M7BWqfDdsSGo/VEedsTI9WEzCRGDImJqIT/m3Wl5AyL58Zp2T453ndumkR7dy+Pby7zyfFCRX8S/keAdcDngduAn4vIJ0XkG0AtgKq+7L8Qw1uvW/nu8yX85I1DfHhWLg99quiCfcW5wxN46gsLGJs2lM8/UszLu6sDHK3zNhxpYOao4STFxzgdimNcLmFBQSqbjtZHxHz8PRVNbDl2is8syicmyjc19zGpiSwdn86TW8sj6masS373VPU9VX1KVVeq6mvAR4GZQB6eXwJmEH725iEe23yCL1xVwE8+OuOS/6HThsbxxN3zmTlqOPc9sZ1X90RO0m/u6GZ3RSOLCiK3nNNnQUEaVU0dlDWE/1yd36wrZWhcNB+bO8qnx/34vDHUtnTy1v7IebXcnxuv/qpgpqoHVfUfVPVeVT12vseY/ik/dYZfv1fKLTNz+NYNE+nvt3FYQgyPfHYeU3OH8d3n90bMGNjNRxtwKywsTHM6FMf1taRuKg3vsk5lYzsv76nm9itGkezjV3XLJqSTlRzPH98/4dPjBrN+3XglIveJyOizPygisSKyXET+AHzKP+GFtx+tOYBL4Js3TBzw1ybERvHvt0yloa2T/33zsB+iCz4bjzYQH+Ni1ujhTofiOM9YiTg2hnkd/2HvKITPLM73+bGjo1zcPncU6w7XcSICXilB/xL+9UAv8ISIVHlHKhwDDgN3AD9T1Yf9GGNY2nr8FC/vruYLVxWQPezyWuumjxzOx4pG8fDG4xypbfFxhMFnw5F6rshLGfANN+FIpK+O3xC2dfyWjm6efL+cG6dl+6399GNXjEKAJ7ZGxll+f2r4Har6S1VdBIwBrgZmqeoYVf28qu7we5Rhxu1Wvv/iPrKHxXPPksH1AX/9ugkkxEbxvRf2he0PPkBtcweHa1tZbOWcDywsSKW+tZMjta1Oh+IXf9paTktnD5/zw9l9n+xhCSyfmMmfi8vp6gn/i7cDuuStqt2qWq2qjQAiYq+tL8MzOyrZU9nEN6+fSELs4M5W04bG8Q8rxrP+SD2v7a3xUYTBp2+cwiJL+B9YWOD5XoRjWaen183vNxxnbl4KM0b5N83cOX809a1dvL4vfH9++vQr4XtHIs8Vkc+KyE9E5DURqQSO+ze88NPW2cN/rznAjFHDWTUjxyfH/MT8MUzITOIHL+2nvavXJ8cMNhuONDB8SAyTL/OW+nA0KmXIB9v5hZvX9p6ksrGdz13pv7P7PkvGpZM7PIE/bgn/sk5/unSOA4eAHwKzgKPANDxlHTvDH6AH3j1KbUsn/7JyMq5B3jHYJzrKxfdWTaGysZ0H3j3qk2MGE1Vl45F6FoxN9dn3LFwsLEhlU2kDbnd4lfP+VFxOzrB4rp7k//1oo1zCHXNHsfFoA6V14Vke69OfM/wX8dxt+xtVvU9Vfwl0qmrkNK/6SFVjOw++V8qqGTnMGePbrdYWFKRy0/RsHnj3KOWnwqvj4HjDGaqaOqwd8zwWFKTS1N7Nvupmp0PxmZqmDtYfruPWOSMHPUahvz5aNIpol/BEmLdo9uei7X3ASuBGEdkqIjcA4XU6ESCPbCqjx6184/oJfjn+t2+chKrnRpVw0jfK1i7Y/q0FBX3z8cOnrPPMjgrcCrfOHhmwNTOS41kxOZO/bKugsyc8y6LQzxq+qpZ5Z+Z8Gs/dtVkissyPcYWdzp5eniou55pJGX7bgDpneAKrZ+bwVHE5p9u6/LKGEzYcqSdnWDx5qbZx97myhyUwNi0xbC7cqip/2VbBFXkjyEtLDOjaHy0axekz3aw7FL6z8vt70fYHIjJGVfeq6oeBZcC3ReTd/i4kIvEi8r6I7BKRvSLyb5cbdChaU1LDqbYuv4/1/fySsXR0u3ksTIZC9bqVTaUNLCxM6/edyJFmQUEqW0obwqKtcEd5I6V1bdw2J3Bn930WFaaRHB/NK2E8rqS/bZlfAV73dufcBmxT1WuA7w9grU5guarOwDOL53oRmT+wcEPX45tPMCZ1iN/LEuMzk7hqfDp/2FRGR3fovzTdVdFI45lurhxn5ZwLWTI+nbauXorLQn9s9l+2VZAQE8VN033TwTYQsdEurp2SxRv7ToZtWae/Cf+kqk4AfgSsBo6IyI+Biv4upB59l8BjvH8i4lrAwZoW3j9+ijvnjQ5Il8ndS8ZS39rJ8zsr/b6Wv63dX0uUS7hqfLrToQStxYVpxEQJ7xysczqUQeno7uXFXVXcMDWLoReYGOtvN03LpqWzh/WHw7Os09+ErwCq+raqfgKYDpwBSkRkcn8XE5EoEdmJZ6zyG6q65TyPuVtEikWkuK4utP8D9/njljJio13cNse30/4uZGFBKpOzk/nNumMh36639kAtc0aPYPiQWKdDCVqJcdHMy09l7YHQbpx7fd9JWjp6HCnn9Okr67wcpmWdAd1pKyIuEVkFPIpnp6vvAsf6+/Wq2quqM4GRwFwRmXqexzyoqkWqWpSeHvpndW2dPTyzvZKbpmWTkhiYpCUifH5JPkdqW3n3UOj+0qxuamdfdTPLJmY4HUrQWzohnSO1rSHdkvuXbRXkDk9gvoOb08dGu1gxOXzLOv1N+ENF5EdAKXA7cL+qTlTVH6lq+0AX9Y5meBvPYLaw9sKuKlo6e7hr/uhLP9iHVk7PISs5PqRbNN8+4PlldfUkS/iXstz7SzFUd0Krbmpn3eE6bp2d6/jNdTdNz6Klo+eDduBw0t+EfwqoBmar6sdVde1AFxKR9L7ZOyKSAKwADgz0OKFEVXlscxkTs5KYPdq3N1pdSkyUi88symPj0QZKKpsCuravrD1QS+7wBMZlDHU6lKCXn5bImNQhIVvWeWZ7Japwq4PlnD6LC9NJio/m5d3hN1unv334U1X1flUdTBtANp7Z+ruBrXhq+C8N4nhBb1dFE3urmrlz/hhHWgrvmDeaoXHR/DYEz/I7unvZcKSe5RMzrB2zH0SEZRMy2Hi0IeS6s1SVp7dVMDc/hTGpge29Px9PWSeTN/bVhEWr69l8s0FkP6jqblWdparTvb9ABtLSGZIe21xGYmwUH5qV68j6yfEx3H7FKF7cXU1104Arb47aXNpAe3cvy62c02/LJmbQ2eMOuWFq2080Ulrfxm0BvLP2UlZOz6Y5DMs6AUv4kaapvZsXd1Vxy6xcx1rMAD61MA+3Kk+E2CTAtw/UEh/j+mArP3Np8/JTSIiJ4u0Qq+M/s72C+BgXN07PdjqUD3xQ1gmzbh1L+H7yWkkNnT1uPloUmFbMCxmVMoRlEzJ4Yms53b2h8fJUVXnrQC2LCtKIj7HdrforPiaKRYWe9sxQ2Qyns8fTe3/9FOd678+nr6zz+t7wKutYwveTF3dXMSZ1CNNHDnM6FO6aP5q6lk5e33vS6VD65UhtKxWn260d8zIsnZBBxel2jobImN+1+2tp7ujhw0FUzulz0zRvWedo+JR1LOH7QX1rJxuPNnDz9JyguOB41fgMRo5ICJn5On2dJsst4Q9Y3y/JvpbWYPf09koyk+OCciezxePSSIqL5pXd4VPWsYTvB6+W1NDrVm720Y5WgxXlEj4+bzSbShtCYrPztw7UMjEriRw/bVwdznKHJzAhMykk2jMbWjt552Att8zKDdjc+4GIi47ylHX2nQyZcuilWML3gxd3VTEuYygTspKcDuUDHy0aRWyUi8c2B/fF26Yz3WwrO21n94OwdGI6W4+foqWj2+lQLurFXVX0uJUPzwq+ck6fa6dk0dTezdbjoT+YDizh+1x1Uztbj58KmrP7PmlD47hhWhZPb6vgTFeP0+Fc0HuH6+h1q91dOwjLJ2TQ49agbyl8enslU3OTg+rE6FxLxqcRF+3ijX2hcf3rUizh+9jLu6tR9fTxBpu75o+hpbOHF3ZWOR3KBa09UMuIITHMHBXYO5PDyewxI0iKjw7qss6hky3sqWwK6rN7gCGx0SwuTOONfSdDpvPpYizh+9iLu6uZmpvM2PTgGwdQNGYEE7OSeHRzWVD+5+3s6WXtgVqWTsgIyppuqIiJcrF0QgZv7q8N2trzM9sriXYJq2YG1yvh81kxOZOK0+0cqAn+61+XYgnfh040nGFXeSM3O7B5Q3+ICHfOH8PeqmZ2ljc6Hc7fePdgHU3t3awKsnJYKFo1I4dTbV1BOde91608t6OSpRPSSRsa53Q4l3T1pExECIuyjiV8H3ppj6dUclMQlnP6fGhWLomxUTwahC2az++sIiUxlsW2u9WgXTU+nWEJMTwXhJvgbDraQE1zR1D23p9PelIcs0YNt4Rv/tqLu6qZPXq43zYp94WhcdF8aHYuL+2upqG10+lwPtDS0c2b+0+ycno2MVH233KwYqNd3Dgtm9f3nqStM7gu0j+zvYLk+OiQ6sRaMTmLPZVNVDWG1kyqc9lPlo8cqW1hf3Vz0HXnnM+nFuTR1ePmya3lTofygTXeURSrZzozaC4c3TIzh/buXt7cHzxnpi0d3bxaUsPKGTkhNTZjxeRMgKD6Xl4OS/g+8uKuakQ8t2MHu3GZSSwuTOPRTWVBc1Hv+Z1VjE4ZwuzRw50OJWxckZdCzrB4ntsRPGWd53ZU0t7dy8ccnjE1UIUZQxmblhjyZR1L+D6gqry4u4r5+alkJMc7HU6/fGZRHjXNHbxa4vwmD7XNHWw8Ws/qmcExiiJcuFzCzTNzeO9wfVCU7zwbAp1gWu4wZowKvV/sKyZnsrm0geYgv6HtYizh+8Dh2lZK69qCarzrpSybkEFe6hAe3tDvLYn95oVdVbgVK+f4wS0zc+l1a1CM+d16/DQHT7bwifljnA7lsqyYnEl3r/LOwdCYU3Q+lvB9YE1JDSJwnbfOFwpcLuFTC/PYfqKRXQ63aD6/s4qpuckU2laGPjcpO5kJmUk8HwQ32z22uYzk+OiQuM51PrNGjyA1MTakyzqW8H1gTUkNc0aPCJlyTp/b5oxkaFw0v3fwLP9oXSt7Kpu4xc7u/WbVzBy2lZ2m/NQZx2Koa+nk1ZJqbpszioTY0LlYe7Yol3D1pAzeOVAbsjPyLeEP0omGM+yrbua6KVlOhzJgSfEx3DZnJC/vqaa2ucORGJX2p+MAABaWSURBVJ7fUYkIIXvWFwpWe+9mfd7Bnvynisvp7lXunD/asRh8YcXkLFo6e9hcGlrbSPaxhD9Ir+31XPQMxYQP8OmFefS4lccc2AJRVXl+VxULC1LJDLFXR6Fk5IghXJE3gud2VjkyUqPXrfxxywkWFaZSEIQjRwZicWEa8TGhO0wtYAlfREaJyNsisk9E9orIVwK1tj+t2VvD5OxkRqcG781WF5OXlsiyCRn8cUsZnT29AV17Z3kjZQ1n7GJtAKyemcuR2lb2VTcHfO13DtZS2djOXfNC82Lt2RJio1gyLp039p3E7Q6+eVSXEsgz/B7ga6o6GZgPfFFEJgdwfZ+rbe5gW9lprp8ammf3fT6zKI/61i5e2hXYTo5nd1QSG+0K+e9fKLhxWjbRLuGZ7YEv6zy6uYzM5DiuCaGmhou5dkoWNc0d7KlscjqUAQtYwlfValXd7n27BdgPhPSp3evel3WhnrAWF6ZRmDGU364/FrCzllNtXfy5uIKV07NJjo8JyJqRLCUxlhumZfOnreU0nQlcH/mJhjO8e6iO268YHTYjM66Z5Jnm2lfODSWO/AuISB4wC9hyns/dLSLFIlJcVxfc/a6v7a1hbFoi40K8nVBEuHdpAfurm3mlJDBn+Q9vOEZHTy/3Li0IyHoG7l1aQGtnD49sOh6wNR9/vwyXCHfMDe2LtWcbPiSWefkplvD7Q0SGAk8DX1XVvykoquqDqlqkqkXp6emBDq/fGs90seloA9dOyQqLu0NXz8xlfOZQ/uf1Q/T4edxCS0c3D288zvVTsijMCN7djsLNpOxklk/M4HcbjgVk17Pmjm6efL+cFZMyyRoWXhflr5uSxdG6No7UtjodyoAENOGLSAyeZP+4qj4TyLV97a39tfS4NeTLOX2iXMLXrp1AaX0bT2+v8Otaj20+QXNHD/cuLfTrOuZvfXFZAafPdPPE+/4fnPfrd4/S1N7Nl5aH379z3zC11/eF1ll+ILt0BHgI2K+q/xOodf1lzd4asofFMz13mNOh+My1kzOZMWo4P3vzMB3d/unY6eju5aH1pSwZn860keHzvQsVc8akMC8/hd+8V+rXrqza5g4eWn+MVTNymBpGPyN9coYnMH3kMF7bG1rtmYE8w18EfAJYLiI7vX9uDOD6PtPW2cN7h+q4bkoWrjDaik9E+MZ1E6hu6uAxP22Q8lRxOfWtXXzRaveO+eKyQmqaO/w6RfP+tw7T06t87drxflvDaddNyWJXeSM1Tc7ctHg5Atmls15VRVWnq+pM759XArW+L717qI7OHnfI3mx1MYsK01hUmMov3zlKq483zujudfPrd0spGjOCufkpPj226b8rx6UxNTeZX71zlF4/dGUdq2/jya3lfHzeaMakJvr8+MHiuimhV9YJjz6pAFtTUkNKYixX5I1wOhS/+MfrJnKqrYuH1vl2xs5zOyqpbGzni8sKw+JCd6gSEb64tJDjDWd4xQ9TNH/y+kHiol3ct3ycz48dTAozkhibnsjrIVTWsYQ/QJ09vaw9UMs1kzKIDpO+4nPNHDWc66Zk8pt1pZxq6/LJMXvdyq/ePcqk7GSWTgje7qtIcd2ULArSE/nF20d8Om5hT0UTL+2u5u8W55OeFPwblA/WdVOy2FzaENB7GwYjPDOWH60/XE9rZw83hMDOVoPxtWsn0NbVw8/ePOST4720u4rSuja+uKzAzu6DgMsl/J+lhRyoafHphcf/fu0AI4bEcPeSsT47ZjC7bkoWPW7lrQOhcZZvCX+AXi2pISk+mkUFaU6H4lfjM5P41II8HtlUxgu7BjdLvayhje8+V8LU3GRumBrevyhDyeqZOYzPHMo/P7vHJxceNxypZ93her64rJCkCLl7enruMDKT40LmJixL+APQ3evmjX0nuWZSJrHR4f+t++cbJ3FF3gi+8Zdd7Ku6vKFb7V293PPoNkSEX905h6gw6moKdTFRLn5552w6unv50h+3D2p/49NtXXznuRJyhydwV4juaHU5XC7h2slZvHuojvauwA4fvBzhn7V8aNPRBprau8PmZqtLiY128Ys7ZzMsIYZ7Hium8czA6vmqyj8/u4eDJ1v42e0zGZUSmhNFw1lhRhL/+eFpFJed5v977eBlHaOju5fPP1JMZWM7998+k/iY0Nzg5HJdNyWLjm436w4H9ygYsIQ/IK+W1DAkNoqrxkfORceMpHh+ddccTjZ1ct8TOwbUxvfY5jKe3VHJV68ez7IJGX6M0gzG6pm53DV/NL9+r3TAc97dbuVrf95FcdlpfvrRmRTlRV677byxKQxLiOHVkuAv61jC76det/LGvhqWTcyIuDOY2aNH8P3VU1h3uJ4f9/MscFvZab7/0j6WT8zgvjC8tT7cfOemyUzNTeZrT+0c0FaI//XaAV7eXc0/3TCRm6ZH5vWZmCgXN0zN4vW9NUFf1rGE309bj5+ivrWLGyKknHOu2+eO5uPzRvPAu0f57zUHaGjtPO/jVJVtZae49/FtZA9L4KcfnRlWdyOHq/iYKH758TkocO/j22lqv3Sb4aOby/j1u6XcNX90xHTlXMiqmTm0dfUGfbeOJfx+enVPNXHRroguTXzv5incPCOHX75zlIU/Wsu3n93D8fo2AFo7e3hscxk33L+OW3+1iY5uNw/cNYdhQyKjWyMcjE4dwk8+MoOSqiYW/2gt//P6wfNet6k4fYb/u/Yw//p8CcsnZvC9m6dEfKvtvPxUMpPjeG7H4Dra/E2c2OOyv4qKirS4uNjpMHC7lQU/eosZI4fz4CeLnA7HcUdqW/ntulKe2V5Jt9vN/PxUdlc00tbVy+TsZO6aP4bVM3NIjIt2OlRzGfZWNfHzt46wZm8NQ+Oi+dTCMayemcu6w/W8tLuKHScaAc+IhgfummP/zl4/fHkfD288ztZvX8PwIbGOxSEi21T1vInKEn4/bCs7za2/2shPPzaDD80a6XQ4QaO2pYM/bDzOi7uqKcobwV3zxzBr1PCIP9sLFwdqmvn52iO8sqeavjQxOTuZlTOyWTktJ2T3cfaXksomVv58Pf/54WmObvhysYRvv5r7YU1JNTFRwvKJ4bEnp69kJMXzj9dN5B+vm+h0KMYPJmYl84uPz+bQyRY2lzawuDCNsemhvbubP03JSWZseiLP76wM2h2+LOFfgqryyp4aFhWmMSzB6tEm8ozPTGJ8pu1MdikiwuoZufzsrUNUN7WTPSzB6ZD+hl20vYSSymYqG9u50UYCGGMuYdXMHFThpV2B2Rt6oCzhX8KrJdVEueSDLc2MMeZC8tMSmTFyGM/v8t/mMoNhCf8i3G7lhV1VLCxIZUSic1fdjTGhY9XMXEoqm4Nyg3NL+Bex7cRpKk6386FZuU6HYowJETdPz0YEXtgZfGf5lvAv4tkdlSTERIXlVobGGP/ISI5nYUEqz++q8unmMr5gCf8CunrcvLy7mmunZNqNJcaYAVk9I5eyhjPsLG90OpS/ErCELyK/E5FaESkJ1JqD8c7BWprau7nFyjnGmAG6floW8TEunny/3OlQ/kogz/AfBq4P4HqD8tzOSlITY7myMLx3tjLG+F5yfAwfmjWS53ZW+mxfaF8IWMJX1feAU4FabzCa2rt5c38tN8/ICduNyo0x/vWZRXl09rh54v0TTofyActm57GmpJquHrd15xhjLtv4zCQWF6bx6KayQW0f6UtBl/BF5G4RKRaR4ro6Z7YMe3ZHJWPTEpk+cpgj6xtjwsOnF+ZR09zBmiDZDSvoEr6qPqiqRapalJ4e+K0EKxvb2Vx6iltm5drUR2PMoCyfmMGY1CE8vPG406EAQZjwnfbCTs8GBrfMtHKOMWZwXC7hkwvy2FZ2mt0VzrdoBrIt8wlgEzBBRCpE5O8CtXZ/qSrP7qhgzpgRNuvbGOMTHykaSWJsFL/fcNzpUALapXOHqmaraoyqjlTVhwK1dn/tr27h0MlW6703xvhMcnwMHykaxUu7q6ht6XA0FivpnOVPW08QEyXcNM1GIRtjfOeTC8bQ3as8vtnZFk1L+F5N7d38eVsFN8/IIcUmYxpjfGhs+lCWTUjn8S1ldPb0OhaHJXyvPxeXc6arl88uync6FGNMGPrs4nzqW7t4dFOZYzFYwgd63crDG48zNy+FqbnWe2+M8b3FhWksm5DOT984RE2TM7V8S/jAG/tOUnG6nc8uznM6FGNMmBIRvrdqCt1u5Qcv73MkBkv4wO82HGPkiARWTLa598YY/xmTmsi9Swt4eXc16w/XB3z9iE/4JZVNvH/sFJ9akEeUy+6sNcb41xeuKmBM6hD+5fmSgF/AjfiE/7sNxxgSG8VHrxjldCjGmAgQHxPFv62aQml9G795rzSga0d0wq9t6eClXdV8ZM5IhiXEOB2OMSZCLJ2QwQ1Ts/j52iOUnzoTsHUjOuE/vvkEXb1uPrUwz+lQjDER5rsrJxPlEr73wt6A7X0bsQm/o7uXx7eUsXxiBmPThzodjjEmwuQMT+DvrxnPWwdq+dbTe+gJwMz8iN2d+/EtJ6hv7bIbrYwxjvnclfk0d3Tz87VHaGjr5Od3zCYhNspv60XkGf7J5g5++sYhrhqfzqLCVKfDMcZEKBHha9dO4Aerp/DWgVruemgLjWf8twduRCb8H768n65eN/+2aoptcmKMcdwnFuTxi4/PZk9FEx95YBNVje1+WSfiEv7GI/W8sKuKL1xVQF5aotPhGGMMADdOy+YPn51LTVMHt/1qI22dPT5fI6Jq+F09br77fAmjUhK4d2mB0+EYY8xfWVCQyp/uWcCO8tMkxvk+PUdUwn9o/TGO1rXxu08XER/jvwsjxhhzuSbnJDM5J9kvx46Ykk5lYzv/+9Zhrp2cyfKJmU6HY4wxARcxCf8HL+5DUf7l5slOh2KMMY4I+4Svqvzo1QOs2VvDfcvHMXKEbU5ujIlMYV3D73Ur3352D09uLefOeaP5wlV2odYYE7kCeoYvIteLyEEROSIi3/LnWp09vXzpj9t5cms59y0v5N9vmWrjj40xES1gZ/giEgX8AlgBVABbReQFVfX51i+tnT3c82gxG4408N2Vk/m7xTY+wRhjAlnSmQscUdVSABF5ElgN+DThN7V388mHtlBS1cxPPjKDW+eM9OXhjTEmZAUy4ecC5We9XwHMO/dBInI3cDfA6NGjB7xIYmwUeWmJ3Ld8HNdMtvZLY4zpE3QXbVX1QeBBgKKiogEPiY6OcnH/7bN8HpcxxoS6QF60rQTO3kdwpPdjxhhjAiCQCX8rME5E8kUkFrgdeCGA6xtjTEQLWElHVXtE5EvAa0AU8DtV3Ruo9Y0xJtIFtIavqq8ArwRyTWOMMR5hP1rBGGOMhyV8Y4yJEJbwjTEmQljCN8aYCCGqA763KWBEpA4o89Hh0oB6Hx3LSeHwPOw5BAd7DsHDl89jjKqmn+8TQZ3wfUlEilW1yOk4Biscnoc9h+BgzyF4BOp5WEnHGGMihCV8Y4yJEJGU8B90OgAfCYfnYc8hONhzCB4BeR4RU8M3xphIF0ln+MYYE9Es4RtjTISIqIQvIj8Qkd0islNEXheRHKdjGigR+bGIHPA+j2dFZLjTMQ2UiHxERPaKiFtEQqqlTkSuF5GDInJERL7ldDyXQ0R+JyK1IlLidCyXS0RGicjbIrLP+3/pK07HNFAiEi8i74vILu9z+De/rxlJNXwRSVbVZu/bXwYmq+oXHA5rQETkWmCtd9z0fwGo6jcdDmtARGQS4AZ+DXxdVYsdDqlfRCQKOASswLNF51bgDlX16b7M/iYiS4BW4BFVnep0PJdDRLKBbFXdLiJJwDbgllD6txARARJVtVVEYoD1wFdUdbO/1oyoM/y+ZO+VCITcbztVfV1Ve7zvbsazc1hIUdX9qnrQ6Tguw1zgiKqWqmoX8CSw2uGYBkxV3wNOOR3HYKhqtapu977dAuzHs292yFCPVu+7Md4/fs1JEZXwAUTkhyJSDtwJ/IvT8QzSZ4FXnQ4iguQC5We9X0GIJZlwJCJ5wCxgi7ORDJyIRInITqAWeENV/focwi7hi8ibIlJynj+rAVT126o6Cngc+JKz0Z7fpZ6D9zHfBnrwPI+g05/nYMxgichQ4Gngq+e8gg8JqtqrqjPxvFKfKyJ+LbEFdMerQFDVa/r50Mfx7L71r34M57Jc6jmIyKeBlcDVGqQXYQbw7xBKKoFRZ70/0vsx4wBv3ftp4HFVfcbpeAZDVRtF5G3gesBvF9PD7gz/YkRk3FnvrgYOOBXL5RKR64FvAKtU9YzT8USYrcA4EckXkVjgduAFh2OKSN4Lng8B+1X1f5yO53KISHpfl52IJOBpBvBrToq0Lp2ngQl4OkTKgC+oakidoYnIESAOaPB+aHMIdhp9CPg5kA40AjtV9Tpno+ofEbkR+BkQBfxOVX/ocEgDJiJPAEvxjOQ9Cfyrqj7kaFADJCKLgXXAHjw/zwD/7N03OySIyHTgD3j+L7mAp1T1+35dM5ISvjHGRLKIKukYY0wks4RvjDERwhK+McZECEv4xhgTISzhG2NMhLCEb4wxEcISvjHGRAhL+CaoiEivd7+Cvd454V8TEZf3cxu9f+cNZpa7iHxPRL5+GV/XepHP3SIiKiITLzeu/qzTj6+9yjvrvldEjonI1wYbjwkflvBNsGlX1ZmqOgXPreY34J13pKoL/bmweFzuz8QdeOaZ3+HDkC5HFvBnIFVV81X1Jw7HY4KIJXwTtFS1Frgb+JI3GZ995hslIr/xvhJ43TuLBBG5y7uL0E4R+bV30xJE5NsickhE1uMZr4H343neHawewTO0apSIPCci27zHvvtScXonNi4G/g7PfJ2zj73/AnF+17vuehF54nyvOC70XC7hk8CbQFM/HmsijCV8E9RUtRTPrJGMcz41DviF95VAI3CrdyetjwGLvCNne4E7RWQOnkQ8E7gRuOI8x/qlqk5R1TLgs6o6BygCviwiqZcIczWwRlUPAQ3e9S4W5xXArcAMPK9g/mabxws9l0vEAZ4ZRY8CjSLy8X483kSQsBuPbCLGMVXd6X17G5AHDAfmAFs9wxRJwLOxRArwbN90URE5d8Jl2Tnbyn3ZO+ANPOOQx/H/htWdzx3A/d63n/S+v+0icaYBz6tqB9AhIi+e55hXX+C5XJD3+sF/AzcD7wTr6GzjHEv4JqiJyFg8Z7fnJrvOs97uxZMQBfiDqv7TOcf46iWWaTvrsUuBa4AFqnpGRN4B4i8SXwqwHJgmIorn1YiKyD9eJM7+OO9zuYR7gP9R1bcH8DUmglhJxwQtEUkHHgD+bz/PVt8CbhORDO/Xp4jIGOA94BYRSRDPhtc3X+QYw4DT3mQ/EZh/iTVvAx5V1TGqmufdTe0YcOVFvmYDcLOIxHvr/ysH8FwQkbdE5HxbK8bjuWhrzHlZwjfBJqGvLRPPxcfXgX/rzxeq6j7gO8DrIrIbeAPI9m52/SdgF549gLde5DBrgGgR2Q/8CM9G8RdzB/DsOR97mot066jqVjwbp+z2xrOHcy6yXui5eLuICjn/JuQ/BlaIZyvJN0Qk+xKxmwhj8/CNcYCIDFXVVhEZgucVyN3eX0yX+rqpeC4q/8MlHvcHPBtqvOybiE04sBq+Mc54UEQm4ynD/KE/yR5AVUuASyX7lUAinldIxnzAzvCNMSZCWA3fGGMihCV8Y4yJEJbwjTEmQljCN8aYCGEJ3xhjIoQlfGOMiRCW8I0xJkL8/yQm/PaIT5GRAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "source": [
+        "fig, ax = plt.subplots()\n",
+        "\n",
+        "ax.set_xlabel(r\"Dihedral Angle, $\\xi$\")\n",
+        "ax.set_ylabel(r\"$\\nabla A(\\xi)$\")\n",
+        "\n",
+        "ax.plot(mesh, A)\n",
+        "plt.gca()"
+      ]
     }
-   ],
-   "source": [
-    "fig, ax = plt.subplots()\n",
-    "\n",
-    "ax.set_xlabel(r\"Dihedral Angle, $\\xi$\")\n",
-    "ax.set_ylabel(r\"$\\nabla A(\\xi)$\")\n",
-    "\n",
-    "ax.plot(xi, dA)\n",
-    "plt.gca()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Kf_CMdih90Cd"
-   },
-   "source": [
-    "\n",
-    "Finally, we make use of the `pysages.approxfun` module to build a Fourier series approximation to the free energy\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "id": "pTIGVSSqKdbs"
-   },
-   "outputs": [],
-   "source": [
-    "from pysages.approxfun import SpectralGradientFit, build_evaluator, build_fitter\n",
-    "\n",
-    "fourier_model = SpectralGradientFit(grid)\n",
-    "fourier_fit = build_fitter(fourier_model)\n",
-    "evaluate = build_evaluator(fourier_model)\n",
-    "\n",
-    "fun = fourier_fit(dA)\n",
-    "A = evaluate(fun, compute_mesh(grid))\n",
-    "A = A.max() - A"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
+  ],
+  "metadata": {
+    "accelerator": "GPU",
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 303
+      "collapsed_sections": [],
+      "name": "Butane-FUNN.ipynb",
+      "provenance": []
     },
-    "id": "7_d_XfVLLkbI",
-    "outputId": "3bd503ea-fe33-4a57-a28d-1c3a70e63c50"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f70461a4bd0>"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
+    "jupytext": {
+      "formats": "ipynb,md",
+      "main_language": "python"
     },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAENCAYAAAAMmd6uAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3iU15X48e+ZUUMNoYqQBAIkekdgY4oLJdgmsRNcU5w4hfRsym42m+xu2iabtomd/NJIcezE68Q1iQs2xZjiAogOEkiiCiHUQAKhLp3fH5KyhFAkMfO+U87neXgsmNF7zxjm6M557z1XVBVjjDGhz+N2AMYYY5xhCd8YY8KEJXxjjAkTlvCNMSZMWMI3xpgwYQnfGGPChKMJX0Q+JyL7RWSfiDwhIjFOjm+MMeHMsYQvIlnAZ4ACVZ0EeIH7nBrfGGPCXYQL4w0SkXYgFjh5pSenpqZqbm6uE3EZY0xI2L59e62qpl3qMccSvqpWiMgPgONAM7BaVVdf6Xtyc3MpLCx0JD5jjAkFInLsco85WdIZAtwBjASGAXEi8t5LPG+FiBSKSGFNTY1T4RljTMhz8qbtIuCIqtaoajvwLHDDxU9S1ZWqWqCqBWlpl/xUYowxZgCcTPjHgetFJFZEBFgIFDs4vjHGhDXHEr6qbgGeBnYAe3vGXunU+MYYE+4cXaWjql8FvurkmMYYY7rZTltjjAkTlvCNMSZMOL3xypig1NzWyf9uPU5rRyexkV5ioyIYFOVlWFIMM0ckux2eMX1iCd+Yqzjb0s6HfreNbUfPXPLxzy8ew2cW5jsclTH9ZwnfmCuobWzl/b/dSknVOX5y/3QWT8igqa2TprYOmts6+fmGQ/xwTQlej/DJm/PcDteYK7KEb8xlVNQ3875fb+FkQzO/eqCAm8amAxAT6SU5LgqA7981la4u5fuvHCTSK6xYMNrNkI25Ikv4xlzC4ZpG3vvrLZxr6eD3H7qOWbmXrtN7PcIP7p5KR5fy7ZcO4PV4+NC8kQ5Ha0zfWMI35iINze3cu/IturqUJ1Zcz6SswVd8foTXw0P3TqOzS/nmC0VEeoUH5uQ6E6wx/WDLMo25yC82HKK2sZVHHpx11WTfK8Lr4cf3T2fR+Ay+9tf9HK5p9HOUxvSfJXxjLlDZ0MxvNx/hzmlZTMlO6tf3Rno9fGf5ZGIivfxobamfIjRm4CzhG3OBh9aUotq91HIgUuOjeXBuLs/vPklx5VkfR2fMtbGEb0yP0qpzPLW9nPfNGUFOcuyAr7Ni/mgSYiL4n9UlPozOmGtnCd+YHt99+QBxURF86hrX0w+OjeSjC0axtriKnccvvVnLGDdYwjcG2HrkNGuLq/nYTaMZ0rPG/lo8OHckKXFRNss3AcUSvgl7qsp/ryomIzGaD871zRr6uOgIPn7TaDaX1fLmoTqfXNOYa2UJ34S9V/afYufxej63aAyDorw+u+57rx/B0MQYfrD6IKrqs+saM1CW8E1YU1V+uKaEvPR47pqZ7dNrx0R6+fTCPLYfO8NrB2t8em1jBsKxhC8iY0Vk1wW/zorIZ50a35hL2XG8npKqRj4yfyQRXt+/He4pyGF4ciwPr7N1+cZ9Tp5pe1BVp6nqNGAm0AQ859T4xlzK09vLGRTp5fYpw/xy/UivhwfmjGBXeT1l1ef8MoYxfeVWSWchcEhVj7k0vjE0t3Xy/O5KbpucSXy0/9pK3TEtC69HeHp7hd/GMKYv3Er49wFPuDS2MQCs2ldJY2sHdxf4tnZ/sbSEaG4ak8ZzO0/Q2WU3b417HE/4IhIFvAN46jKPrxCRQhEprKmxG13Gf54qPMGIlFiuG+n/IwqXz8ym6mwrr5fV+n0sYy7HjRn+rcAOVa261IOqulJVC1S1IC0tzeHQTLg4XtfEm4fruGtGNiLi9/FuGZdOYkwEz+w44fexjLkcNxL+/Vg5x7js6R0nEOmeeTshJtLL26cO45X9pzjX0u7ImMZczNGELyJxwGLgWSfHNeZCXV3KM9tPMC8vlWFJgxwbd/nMbFrau1i195RjYxpzIUcTvqqeV9UUVW1wclxjLvTGoToq6pu5pyDH0XGn5yQxKjWOp62sY1xiO21N2HmysJzEmAgWT8hwdFwRYfnMbLYeOU356SZHxzYGLOGbMNPQ3M4r+09xx7QsYiJ91zenr+6cnoUIdvPWuMISvgkrz+8+SWtHl+PlnF5ZSYOYMyqFZ3dUWEM14zhL+Cas/GVXBWMzEpiUlehaDMtnZHP8dBOFx+xwFOMsS/gmbNQ2tlJ47AxLJw11ZO395SydNJTYKC/P7rBWC8ZZlvBN2Hi1uBpVHL9Ze7G46AhuHpfO2uIquqzVgnGQJXwTNlYXVZGVNIiJw9wr5/RaPD6DmnOt7KmwFcrGOZbwTVhoautgU2kNiydkuFrO6XXT2DS8HmFt0SU7jBjjF5bwTVjYVFpLa0cXS1wu5/RKio2iYMQQ1hZbwjfOsYRvwsLq/VUkxkQwy4HOmH21eEIGB06ds01YxjGW8E3I6+js4tUDVdwyLp1IPxxjOFALx3d/2rBZvnFK4PzrN8ZPth87w5mmdpZMHOp2KH9nZGoceenxlvCNYyzhm5C3uqiKKK+HBWMC73yFReMz2HL4NGetZbJxgCV8E9JUlTVFVczNS/HrubUDtXhCOh1dyoaDdrqb8T9L+CakHaw6x/HTTSyeEFjlnF7TcoaQEhdlZR3jCEv4JqSt2V+FCCyakO52KJfk9Qi3jEtn/YFq2ju73A7HhDhL+CakrSmuYlpOEukJMW6HclkLx2dwtqWDbUdPux2KCXFOH3GYJCJPi8gBESkWkTlOjm/CS2VDM3tONLjeO+dq5uenEhXhYW1RtduhmBDn9Az/YeBlVR0HTAWKHR7fhJHetgVLArR+3ysuOoK5o1NYU3zKeuQbv3Is4YvIYGAB8BsAVW1T1Xqnxjfh57WDNYxIiSUvPd7tUK5q0YQMyk83U1rd6HYoJoQ5OcMfCdQAj4jIThH5tYjEOTi+CSOtHZ28caiOGwNw7f2lLBxnu26N/zmZ8COAGcDPVXU6cB740sVPEpEVIlIoIoU1NbY22QzM9qNnaG7vZEF+cCT8oYNjGDc0gU0ltW6HYkKYkwn/BHBCVbf0/P5pun8A/B1VXamqBapakJYWHG9WE3g2lNYQ6RXmjE5xO5Q+WzAmjcJjp2lq63A7FBOiHEv4qnoKKBeRsT1/tBAocmp8E142ltQyc8QQ4gJwd+3lzM9Ppb1T2XLYlmca/3B6lc6ngcdFZA8wDfi2w+ObMFB9toXiyrPcOCYwN1tdzqzcZKIjPGwstVKm8Q9Hpz+qugsocHJME342lnbXwReMSXU5kv6JifQye2Qym0qtjm/8w3bampCzsaSG1Phoxg91/+za/lqQn0ZZdSMn65vdDsWEIEv4JqR0dimbSmtYkJ+Kx+P+2bX9Nb/nU8lmm+UbP7CEb0LKvooGzjS1c+PY4FzhNTYjgbSEaKvjG7+whG9CysaSGkRgXl5w1e97iQjz81PZXFZLZ5e1WTC+ZQnfhJSNpTVMGjaYlPhot0MZsAX5adQ3tbP/ZIPboZgQYwnfhIyzLe3sOF4fNO0ULmduz6cTW61jfM0SvgkZb/SUQQLx7Nr+SEuIZkJmIhtLrI5vfMsSvgkZG0pqiY+OYPrwJLdDuWbzx6Sy4/gZGlutzYLxHUv4JiSoKhtLarhhdAqR3uD/Z70gP62nzUKd26GYEBL87wxjgMO156mobw7a5ZgXmzliCDGRHqvjG5+yhG9CQm+9O1jaIV9NTKSX60am2Hp841OW8E1I2FxaS25KLDnJsW6H4jPz81M5XHOeE2ea3A7FhAhL+CbotXd28dbhOublB+dmq8vpXW1kbRaMr1jCN0Fv5/F6zrd1Bu3u2svJT48nLSGa1w/ZjVvjG5bwTdDbXFqDR2DO6NBK+CLCvLxU3iirpcvaLBgfsIRvgt6mslqmZCcxeFCk26H43A2jU6g738bBqnNuh2JCgKMJX0SOisheEdklIoVOjm1CU0NzO7vL65kfYvX7Xr1tFl4vszq+uXZuzPBvVtVpqmonX5lr9uahOro0eLtjXs2wpEGMSotjsyV84wNW0jFBbXNZDbFRXqYPH+J2KH4zLy+VrUdO09bR5XYoJsg5nfAVWC0i20VkhcNjmxC0ubSW60elEBURunOXuXmpNLV1squ83u1QTJBz+l0yT1VnALcCnxSRBRc/QURWiEihiBTW1NguQ3N55aebOFrXFLLlnF7Xj0rBI1hZx1wzRxO+qlb0/LcaeA6YfYnnrFTVAlUtSEsLjW3yxj96E2Co3rDtNXhQJJOzk+zGrblmjiV8EYkTkYTer4ElwD6nxjehZ3NpLRmJ0eSlx7sdit/Ny0thV3k951ra3Q7FBDEnZ/gZwGYR2Q1sBV5U1ZcdHN+EkM4u5fVDtczLS0NE3A7H7+bmpdLZpWw9ctrtUEwQi3BqIFU9DEx1ajwT2vafbKC+qZ15+Sluh+KIGcOHEB3hYXNZLQvHZ7gdjglSobu0wYS03j7xc0P8hm2vmEgvs0cmWx3fXBNL+CYobS6tZdzQBNITYtwOxTFz81IpqWqk+myL26GYIGUJ3wSd5rZOth87E/LLMS/W+3pfP2SzfDMwlvBN0NlypI62zq6Q639/NRMyE0mKjeT1MmuXbAbGEr4JOhtKaoiO8HD9qPC4YdvL4xFuGJ3C62W1qFq7ZNN/lvBN0NlQUsN1o1KIifS6HYrj5ualUtnQwqGa826HYoKQJXwTVMpPN3G45jwLwqyc06v3kPbNdri5GQBL+CaobOxJdDeNDc+2GznJseSmxP5tWaox/WEJ3wSVjSU1ZCUNYnRa6LdTuJz5+Wm8ebjO2iWbfrOEb4JGe2cXr5fVsWBMali0U7ic+fnd7ZK3HzvjdigmyFjCN0Fj5/F6Gls7uHFMeJZzes0ZnYLXI2yyOr7pJ0v4Aa6lvZP1B6v55gtF/HLDIRpbO9wOyTUbSqrxeoQbwmzD1cUSYiKZMTzJ6vim3xxrnmb67vT5Nv66q4LXSmp481AdrR1dREV4aOvo4ucbDvGR+aN4/w25xEeH11/fxpJaZgxPIjEm0u1QXLcgP40fri2hrrGVlPhot8MxQcJm+AGmtrGVd/3sdb72fBHH6pp493XDefSDs9nz1SX8+ZNzmZ6TxPdfOci8777KT9eX0dzW6XbIjqhtbGVvRUPYl3N6zR+Thiq8fsh23Zq+C68pYoA739rBh363jcqGFp74yPXMGf33O0mn5STxyIOz2VVez8NrS/j+Kwd541Atv3twNpHe0P7Z3VuvXmAJH4DJWYMZPCiSTSU1vGPqMLfDcU1HZxcn61uoaWyh5lwbNY2t1DW2Mi8vlYLcZLfDCziW8ANEe2cXH398B3srGvjl+wr+IdlfqDfxP1lYzhef3sO/P7eP7yyfHNIrVzaW1JIcF8WkYYPdDiUgeD3CvLxUNpV2t1kI5b/7yzle18RHHivkYNW5f3js4XWlfOzG0Xxu0ZiQPuC+v/qd8HuOJ2xR1fCoJTigq0v516f3sLGkhu+8azKLJ/TtgIt7CnI4XtfE/1tfxsi0OD5242g/R+qOri5lY0kNC/JT8XjCL7Fdzvz8VF7cW0lZdSP5GQluh+OoNw7V8onHd6AK37xjIjnJsaQlRJMWH01MlJdvv1jMz187xKbSGh6+b3pY79u40FV/9ImIR0TeLSIvikg1cACoFJEiEfm+iOT1Z0AR8YrIThF5YaBBh5rvvnKAZ3dW8PnFY7hv9vB+fe/nF49h2ZRMvrPqAKv2VvopQncVVZ6l7nyblXMu0tstdENJeC3PfHzLMR74zVZS46P5yyfn8r45udw0Np2JwwaTnhhDYkwk31k+hV+8dyYVZ5q5/cebeHzLMWs4R99u2q4HRgP/BgxV1RxVTQfmAW8B3xWR9/ZjzH8CivsdaYh6ZvsJfrnhMO+5bjifvqVfPzuB7g6KP7h7KjOGJ/HZP+1iV3m9H6J0V29Cm59vCf9C2UNiGZUWFzbLM9s7u/jPv+zjK8/tY35+Ks9+4gZyU+Mu+/ylk4by8mcXMCs3ma88t4+fvXbIwWgDU18S/ouq+k1V3aOqf9vLraqnVfUZVV0O/Kkvg4lINnA78OuBhRtaWto7+d4rB5g+PIlv3DFpwHXYmEgvv3qggPTEaD786DZO1jf7OFJ3bSipYeKwRNISbPnhxRbkp7HlSB0t7aFfYf3ys3t57M1jrFgwil+/f1afludmJMbw6IOzuX1yJg+tLeHgqX+s94eTviT8j/Z+ISL3XfiAiGSIyK39GO8h4IuANQEBHn3jKFVnW/nXpePwXmNtOiU+mkc+MIvzrZ187a/7fRSh+xqa29lx7Iwtx7yM+fmptLR3hXybhRf3VPLU9hN86uY8vnzb+H69Xzwe4Rt3TCQxJpJ/fmo3HZ3hm376kvBHiEjvHaGfX/TYY8C9wONXu4iILAOqVXX7VZ63QkQKRaSwpiZ0a5NnW9r5+YZDLBiT5rODPPLSE/j0wjxWF1Wx/kC1T67pttcOVtPRpSzq443scHP9qBQivfK3LqKh6FRDC19+bi9Tc5L4p0X5A7pGSnw037xzUvcquI2HfRxh8OhLwq8Dvi0idwARIrLggscyVfUDwKN9uM5c4B0ichT4I3CLiPzh4iep6kpVLVDVgrS00J3V/WrjYeqb2vni28b69LofnjeKUWlxfO35/SHxMX/1/irSE6KZlp3kdigBKS46gpkjhrCxJDTr+F1dyj8/tZu2ji4eunfaNe03uW1yJrdPzuThtaWUXGIpZzjoy/+9u4FNwEeAu4CfiMgDIvJFoBpAVV+82kVU9d9UNVtVc4H7gFdVtT83e0NGzblWfrP5CLdPzmRSlm/XlUdFePj6OyZyrK6JlUE+k2lp7+S1g9UsnpBhyzGvYMGYNIorz3KqocXtUHzukTeOsrmslv98+wRGXuEGbV99/Y6JxMdE8C9hWtq5asJX1Y2q+qSqLlPVV4B7gGlALt0/BEw//XR9Ga0dXXx+yRi/XH9+fhq3T87kp+vLKD/d5JcxnPDGoVrOt3WyZOJQt0MJaIvHd5e71h2ocjkS3zpw6izfffkAi8ZncN+sHJ9cMzU+mm/cMZHdJxr41aYjPrlmMOnLOvy/m1qp6kFV/byqfkJVj1zqOVejqq+p6rL+hRoaTpxp4n+3HOfumdl+3Qzy78u6b2x9/fngvYG7en8VCdERzAmzw8r7Ky89nuHJsawtCp2E39LeyWf/uIvEmEi+6+Nd5LdPzuTWSUP50ZoSjtaG19nAfVqHLyKfFpG/2xEkIlEicouIPAq83z/hhZ6H1paCMOCbT32VOXgQ/7Qwn7XF1UGZCDq7lLXFVdw0Lt22xl+FiLBofAavH6rjfIi0z/7lhsMcOHWO7981xefdQEWEr79jIgis3BTcZc/+6ss7aSnQCTwhIid7dtgeAUqB+4GHVPV3fowxZJRVN/LsjhM8cP0IMgcP8vt4D84dSV56PF9/Ifhu4O48fobaxjaW2OqcPlk0IZ22jq6Q2IRVc66VX248xK2ThnLzuHS/jJGeGMPyGVk8s/0EdY2tfhkjEPWlht+iqj9T1bnACGAhMF1VR6jqR1R1p9+jDBGPbzlGhMfDx25ypudNVISHr719IuWnm/nDW8ccGdNXVhdVEemVsD2svL9m5SaTGBPBuuLg+zR3sYfXldDW0cUXl47z6zgfmjeK1o4ufh9k741r0a/PyqrarqqVqloPICK2Vq6PWto7eW5nBUsmZpDq4IEV8/JTmZuXws9eC57TslSVV/af4obRqSTYYSd9Eun1cNPYdF49UE1nV/D2jCmrbuSJreW857rhPlmVcyV56fEsHJfO7988FnSfgAeqTwlfROJEZLaIfFBE/kdEXhGRCuCof8MLHauLqqhvaue+Wf1rjuYL/7xkLKfPt/HI5uBYlVBa3cixuiaWTLRyTn8smpBB3fk2dpUH767b7718gEGRXj690L/3uHp9eP4o6s638eyOCkfGc1tfVukcBUqAbwHTgUPAZLrLOjbD76M/bTtO9pBB3HCFPvf+Mn34EBaNT2flpsM0NLU7Pn5/rd5/Cvi/5Yamb24ck0aER1hTFJy7rLcdPc3qoio+duMoxz4FXz8qmclZg/n15sN0BfEno77qywz/eeA08CtV/bSq/gxoVdXg/FflguN1TbxeVse9BTmubSD6/OKxnGvpYOWmwO8YuLqoiunDk0hPjHE7lKAyeFAk141KDso6vqry7ZeKyUiM5kPzRjk2rojw4fkjOVxznldDpB3JlfTlpu2ngWXAbSKyradZWuj/KPShJwvL8QjcVZDtWgwThiWybEomj7x+lNoAXpVwsr6ZPScaWDLBNlsNxKLxGZRWNwbd+vJV+06x83g9X1g8lkFRXkfHvm1yJllJg/hVGCzR7FMNX1WP9fTM+QDdu2uHisjNfowrZHR0dvHU9nJuGpvuyFLMK/nc4jG0tHfys/WBO8tf2zM7tfr9wCzqKYOtDaJZfltHF997+QBjMxJYPtP5SVGk18ODc3PZcuQ0e06E3nkSF+rvKp39qvou4GbgKyKywT9hhY4NJTVUnW3lXh9tDb8Wo9PiWT4jmz9sOUZlQ2D2zH9l/ylGp8XZkXQDlJMcy9iMBNYVB0954untJzha18S/3jr2mtuED9S9s3JIiI4I+XYLA9rCqKpbVHUR8A0fxxNy/ritnNT4aG7x0waS/vrMwnxUlR+vK3M7lH9wsr6ZNw7VcfvkTLdDCWqLJqSz9ejpoLhB39bRxU/XlzF9eBI3j3XvPZIQE8n91w3npb2VVJ0NvSZ0va5pz7qqrvNVIKGo+mwLrx6o5q6Z2dfU1tWXcpJjuX/2cJ4qLOdYXWDVeZ/dcQJVuGum+5+Ggtmi8Rl0dimvlQT+LP/p7SeoqG/ms4vG+LRfzkDcNyuHzi7lr7tOuhqHPwVGFgpRT+84QWeXBkQ550KfujkPr0d4eF2p26H8jary1PYTzBmVwvCUWLfDCWpTs5NIjY9mdYD3ULpwdr+g50B2N41Ki2dqThLP7QzdNfmW8P1EVfnTtnKuG5ns9x2D/ZWeGMP7b8jlzzsrKKsOjIMgth45zbG6Ju6Z5d5KplDh8QhLJmbwanF1QDdTC6TZfa93Tc+iqPJsyJ59awnfT3YcP9OdwAoCa3bf66MLRjEo0suP1gbGLP/JwhMkREewdKLV733hXdOzaG7v5OV9p9wO5ZJ6Z/fTcgJjdt9r2ZRMvB4J2Vm+JXw/eWnvKaK8noBdXpgSH80H543kxT2V7D/Z4Gos51raeWlvJcumDnN8DXaomjliCMOTY3l25wm3Q7mk/5vd5wfM7B663xc3jknjL7sqQnLnrSV8P+jqUlbtrWTBmMBu/vXh+aNIjIngR2tKXI3jxT2VNLd3co+LG9NCjYjwrhlZvHGojpP1gbUE98LZ/Y1jAq8b6p3Ts6hsaGHLkdNuh+JzjiV8EYkRka0isltE9ovI150a22m7T9RzsqGF2wJ8eeHgQZGsWDCKtcXV7DzuXsOtJwvLyU+PZ1qOtWbypXdNz0YV/rwrsMoTgTq777V4fAbx0RH8OQTLOk7O8FuBW1R1Kt1n4i4VkesdHN8xq/adItIrLAyC5l8fmDuS5LgofujSLL+s+hw7jtdzT0FOQL75g9nwlFgKRgzhuR0VqAZGeSLQZ/cAg6K8LJ00lJf2VoZc22THEr52a+z5bWTPr8D4V+hDqsqLeyqZl5fK4EGBW87pFR8dwcdvHM2m0lreOlzn+PhPFZ7A6xHunJ7l+Njh4F0zsimtbmRfxVm3QwG6u8YG8uy+1zunZ3GutSOodiz3haM1fBHxisguoBpYo6pbnBzfCXsrGqiobw74cs6F3nv9CNITovn+KwcdnQm2d3bxzI4KbhmXTlqCc4fChJPbJ2cSFeHhmR3u37xtbuvkJ6+WMSt3SMDO7ntdPyqFjMTokFut42jCV9VOVZ0GZAOzRWTSxc8RkRUiUigihTU1NU6G5xMv7T1FhEdYHERnsQ6K8vK5xWPYfuwMf93t3C7D1w7WUNvYGrBLV0PB4NhIFo/P4PndJ2nv7HI1lj+8dYzqc618YcnYgJ7dA3g9wh3TsnjtYDWnz7e5HY7PuLJKp+eIxPV0H5B+8WMrVbVAVQvS0gJ7FnAxVeWlvZXckJdKUmyU2+H0yz0FOUzKSuTbLxU7tlnnsTePkhofbefW+tk7p2dRd76NjSXuTaAaWzv4+YZDzM9P5fpRzh8CNBB3Tsuio0t5cW+l26H4jJOrdNJ6z8AVkUHAYuCAU+M7Yf/Jsxw/3cTtk4Ovl7vXI3z9HROpOtvKT9f7v7HaG4dq2VRay4oFIwOmz1CounFsGslxUa4e4/fI5iOcPt/GF5aMdS2G/powLJFxQxN4LgDKYb7i5DstE1gvInuAbXTX8F9wcHy/W7WvEq9HWBykh3fMHJHMu6Zn8etNR/x6gIaq8r2XD5I5OIYH5uT6bRzTLdLr4R1Th7GmuMqVDpoNTe2s3HSYReMzgm7p7dunDmPH8fqAbSfeX06u0tmjqtNVdYqqTlLVkGqt3F3OOcWcUSkkxwVXOedCX7p1HFERHr75QpHfxnhlfxW7yuv57KJ8YiJtZ60Tls/Ipq2jixf2Ot8J8pcbD3GupYMvLBnj+NjX6tZJ3ZO31fsDuxFdX9lnaR85cOocR2rPc2sQlnMulJ4Yw2cW5rHuQDXr/XDGZ0dnFz9YfZBRaXEsn2E7a50yKau7PPHoG0cdbRlQ29jKI68fZdmUTMZnJjo2rq+MSotnTEZ8wPYk6i9L+D6yam8lHoG3TQzuhA/wgRtGMiotjm+8UERrh283njy7s4Ky6kb+ZclYIqx27xgR4RM351FS1cgqB5PXz9YforWjk88tDr7Zfa+lE4ey5UhdSKzWsXecj7y07xTXjUwhNT7415NHRXj46tsncqT2PL/a6LuDnVvaO3loTQlTswezdFLw/2AMNrdPzmR0Whw/XlfqyCy/rLqR3791lOUzsoP6yMq3TRpKl8LaAD9foC8s4fvAoZpGyqobQyqJ3TgmjWVTMvnR2lI2l9b65Jp/eDNlC5UAABVFSURBVOsYJxta+Nel4wJ+HXYo8nqEzyzM52DVOV7Z799ZvqryH3/eR0ykly8uHefXsfxtQmYiOcmDeNnP/8+cYAnfB3p/8i8Kos1WffGd5VPIS4vnk/+745qPQzzb0s5P15cxPz+VG/ICp/95uFk2ZRij0uJ42M+z/L/sOsmbh+v44tJxQb+LWkRYOnEom0trOdcS+OcEX4klfB9YW1zFhMxEspIGuR2KT8VHR/CrBwoQgY88VkjjADdkdXUpX/vrfs40tfPFtwX3bC/YeT3Cp2/J48Cpc6wu8s+MtaGpnf96sYipOUm8e/Zwv4zhtKWThtLW2cX6g8G3+/9ClvCvUV1jK9uPnQmqVgr9MTwllp++ewaHas7zhSd39XtWqKp844Uint1RwWcW5jM5e7CfIjV99fYpwxiZGsfD68r8Msv//uoDnD7fxrfunITXExqlu+k5Q0hLiOaVIF+tYwn/Gr16oJouJWQTPsDcvFS+fNt4Xtlf1e+Dz3+w+iC/e+MoH5w7ks8tyvdThKY/IrwePnVzHsWVZ1lT7NsbkbvK63l8y3Hef0Muk7JC54e7xyMsmZDB+oPVQd0y2RL+NVpbXMXQxBgmDgu+Ncb98cG5uSyfkc3D60r55YZDfWrE9bPXyvjp+kPcNyuH/1g23m7UBpA7pg0jNyWWH68r9VmH1I7OLr7y3F7SE6L5fBAvw7ycpZOG0tTWySYfLWJwgyX8a9DS3snGkloWTUgP+WQmInzrnZO4ZVw6/73qAG97aCPrD15+Y9ajbxzley8f5I5pw/jWOyeH/P+fYBPh9fDJm/PYf/Ksz5qDPfrmMfafPMt/LpsY0Ed7DtT1o1JIjIkI6k1YEW4HEMzePFRHc3sni4LgZCtfiIn08pv3F7CuuJr/erGIBx/Zxk1j0/jybePp7FJ2l9ez+0QDu8vrKao8y+IJGfzg7qkhU8cNNe+cnsWjbx7lS8/sZUxGAmMyEgZ8rdcOVvPfLxWzcFw6twX5bvPLifR6WDQhg7XFVbR3dgVl07/giziArC6qIi7Ky5zRwdHu1RdEhEUTMlj9uRv5ym3j2X70DEt+tJFbH97El57dy4t7TpISH8XnF4/hJ/dPD8o3RbiI8Hr41QMFDIry8uFHCwe8k3RXeT0f/8MOxg5N4KH7poX0p7mlE4fS0NzOlsPBecC5zfAHqKtLWVdcxY1j04iOCL8GYFERHj6yYBTvnJHFM9tPkJEYw9ScJHJTYkP6DR9qMgcPYuX7ZnLvyrf4+B+28/sPXUdURN9/SB+uaeSDv9tGWkI0v3twdkiWci60YEwagyK9rNpXybz84NtPYtOvAdpb0UD1udawKedcTmp8NB+9cTR3Ts9iZGqcJfsgNH34EL67fDJbjpzmq3/d3+ebuNVnW3jgt1sR4LEPzg76DVZ9ERPp5eZxaawpqnK0CZ2vWMIfoLXFVXgEbh6b7nYoxlyzd07P5uM3jeaJrcd57M1jV31+Q3M7739kG6fPt/HIg7PITY1zIMrAsHhCBtXnWtlT0eB2KP1mJZ0BWlNURUFuMkOCuPe9MRf6lyVjKatu5BsvFLGrvJ7lM7KZMzrl7266H6s7z+/fPMaTheU0tXXy2w/MYkp2cB1qcq1uGZuB1yOs3n8q6A50sYQ/AOWnmzhw6hxfuW2826EY4zMej/DQvdP4zqoD/HlXBc/trCBzcAx3Ts9iStZgntp+gvUHq/GKsHTSUD4yfxRTgyzh+cLg2EiuG5nM6qKqoGsM51jCF5Ec4DEgA1Bgpao+7NT4vrS2ODSbpRkTFx3BN++cxFduH8+64mqe2XGClRsP09mlpMZH8+lb8nnPdcPJSIxxO1RXLZmQwdeeL+JwTSOjgqj1s5Mz/A7gC6q6Q0QSgO0iskZV/XeWnp+sKaoiLz2ekWFUtzThJSbSy+1TMrl9SibV51ooOdXI7JHJ/VrBE8oW9ST8NUVVfPTG4En4Tp5pW6mqO3q+PgcUA1lOje8rDU3tbDlyOuxX55jwkZ4Qw7z8VEv2F8geEsvEYYmsCbJDUVz5GxSRXGA6sOUSj60QkUIRKaypCbxWpK+VVNPZpSHdLM0Yc3VLJgxl+/Ez1JxrdTuUPnM84YtIPPAM8FlVPXvx46q6UlULVLUgLS3N6fCuanVRFanx0UwPw5tVxpj/s3hCBqqwzscdR/3J0YQvIpF0J/vHVfVZJ8f2hdaOTjYcrGHR+HQ81h/GmLA2PjOB7CGDgqqs41jCl+4tmL8BilX1h06N60tvHT5NY2uHlXOMMYgIiydksKmslvMDPA3OaU7O8OcC7wNuEZFdPb9uc3D8a7am6BSDIr3MtTNZjTF01/HbOrrYVBp49xsvxbFlmaq6GQjaOoiqsraomvn5qcREhl+zNGPMP5qVO4Sk2EhW769i6aRMt8O5Kltn1Ud7Kxo4dbbFyjnGmL+J8Hq4ZVw66w5U9+kUOLdZwu+jNUXdzdIW2vp7Y8wFlkzIoKG5nW1HA79HviX8PlpTVEXBiGSSrVmaMeYCC8akER3hYfX+wF+tYwm/D3qbpVk5xxhzsdioCBaMSePlfacCvke+Jfw+6F1nawnfGHMpt00eyqmzLewsr3c7lCuyhN8Ha4qqyE+PD6tDHowxfbdwfAaRXmHV3kq3Q7kiS/hXUd/Uxtajp212b4y5rMSYSObnp7Fq36k+HxHpBkv4V7H+oDVLM8Zc3W2TM6mob2bPicA9+tAS/lW8sq+KtIRopobZMW7GmP5ZPD6DCI/w0r7ALetYwr+CxtYO1h+s5rZJQ61ZmjHmigbHRjI3L5VVewO3rGMJ/wrWFVfR2tHFsqnD3A7FGBMEbps8lOOnm9h/8h86vwcES/hX8PzuSoYmxjBz+BC3QzHGBIHFE4bi9QirArSsYwn/Mhqa29lYUsNtkzOtnGOM6ZPkuCjmjErhpQAt61jCv4w1RVW0dXaxbGrgd8AzxgSOWycP5UjteQ5WnXM7lH9gCf8yXthzkqykQXaUoTGmX5ZMGIpH4KW9p9wO5R9Ywr+EM+fb2Fxay7IpmXQf1GWMMX2TlhDN7JHJAbnr1skjDn8rItUiss+pMQdqddEpOrqUZVNsdY4xpv9um5xJaXUjpQFW1nFyhv87YKmD4w3YC3sqGZESy6SsRLdDMcYEoaUTu8s6f9190u1Q/o5jCV9VNwIBf0JAXWMrbxyqs3KOMWbA0hNjmJ+fxjPbT9AZQC2TrYZ/kVX7TtFp5RxjzDW6pyCHkw0tvF5W63YofxNwCV9EVohIoYgU1tQ4fxL8C3tOMjotjnFDExwf2xgTOhZNSCcpNpInC8vdDuVvAi7hq+pKVS1Q1YK0tDRHx64+28KWI6dZNmWYlXOMMdckOsLLndOyWF1URX1Tm9vhAAGY8N30wp5KVOHtttnKGOMDdxdk09bRFTA3b51clvkE8CYwVkROiMiHnBq7L1SVx7ccY2pOEnnpVs4xxly7icMGM3FYYsCUdZxcpXO/qmaqaqSqZqvqb5wauy/eOFTHoZrzPHD9CLdDMcaEkHsKcthXcZb9J90/GMVKOj0ee/MoyXFR3D7FyjnGGN+5Y9oworwenio84XYolvABKhuaWVNUxT0FOcREet0OxxgTQpJio1g8MYO/7KqgtaPT1Vgs4QP/u+U4CrznuuFuh2KMCUH3FORwpqmddcXVrsYR9gm/raOLJ7aWc8vYdHKSY90OxxgTgublpZI5OMb1m7dhn/BX7auktrGV982xm7XGGP/weoTlM7LZWFLDyfpm1+II+4T/+zePkZsSy4J8Zzd5GWPCy72zcvCI8MsNh1yLIawTftHJsxQeO8N7rx9hxxgaY/wqJzmWuwtyeGJrORUuzfLDOuH//q1jxER6uHtmjtuhGGPCwKduyQPg/71a5sr4YZvwG5rb+fPOCt4xdRiDYyPdDscYEwaykgZx3+wcniosp/x0k+Pjh23C//lrh2hu7+SBObluh2KMCSOfuCkPj0f48bpSx8cOy4RfWnWOX286zF0zs5mUNdjtcIwxYWTo4Bjee90Int1ZwZHa846OHXYJX1X5j7/sIy46gn+7dZzb4RhjwtDHbxpNpNf5WX7YJfy/7DrJW4dP88WlY0mJj3Y7HGNMGEpLiOb9c3L5864KyqqdO+g8rBL+2ZZ2/uvFYqZmD+a+WdZGwRjjno/eOJrYSC8PrXVulh9WCf+Hq0uoO9/Kf905Ga+tuzfGuCg5LooH547khT2VPO/QASlhk/D3VTTw2JtHed/1I5icbTdqjTHu+9QteczOTeYLT+7mrcN1fh8vLBJ+a0cn//7nfSTHRfGFJWPdDscYYwCIifSy8oGZDE+JZcVjhZRU+bee72jCF5GlInJQRMpE5EtOjHm8rom7f/Emu8rr+Y9lExg8yDZZGWMCR1JsFL97cBYxkV4+8NutnGpo8dtYTp5p6wV+CtwKTADuF5EJ/hzz5X2nuP0nmzhae56V75vJHdOy/DmcMcYMSPaQWB55cBYNze184JGtnGtp98s4Ts7wZwNlqnpYVduAPwJ3+GOgto4uvv78fj72h+2MSo3jxc/MZ8nEof4YyhhjfGLisMH84n0zKatu5GN/2E5bR5fPx4jw+RUvLwu4sPv/CeA6Xw/S0NTOA49sZXd5PQ/OzeXfbh1PVERY3KowxgS5+flpfHf5FDaW1qCoz6/vZMLvExFZAawAGD68/2vlE2IiyE2J5WMLRnHrZDuQ3BgTXJbPzOZdM7IQ8f3ScScTfgVwYR/i7J4/+zuquhJYCVBQUNDvH3Eej/DwfdMHGqMxxrjOH8kenK3hbwPyRWSkiEQB9wF/dXB8Y4wJa47N8FW1Q0Q+BbwCeIHfqup+p8Y3xphw52gNX1VfAl5yckxjjDHdbPmKMcaECUv4xhgTJizhG2NMmLCEb4wxYcISvjHGhAlR9f32XV8RkRrgmI8ulwrU+uhabgqF12GvITDYawgcvnwdI1Q17VIPBHTC9yURKVTVArfjuFah8DrsNQQGew2Bw6nXYSUdY4wJE5bwjTEmTIRTwl/pdgA+Egqvw15DYLDXEDgceR1hU8M3xphwF04zfGOMCWthlfBF5JsiskdEdonIahEZ5nZM/SUi3xeRAz2v4zkRSXI7pv4SkbtFZL+IdIlIUK2wEJGlInJQRMpE5EtuxzMQIvJbEakWkX1uxzJQIpIjIutFpKjn39I/uR1Tf4lIjIhsFZHdPa/h634fM5xKOiKSqKpne77+DDBBVT/mclj9IiJLgFd72k1/F0BV/9XlsPpFRMYDXcAvgX9W1UKXQ+oTEfECJcBiuo/o3Abcr6pFrgbWTyKyAGgEHlPVSW7HMxAikglkquoOEUkAtgN3BtPfhXSfchKnqo0iEglsBv5JVd/y15hhNcPvTfY94sAPh0b6maquVtWOnt++RffJYUFFVYtV9aDbcQzAbKBMVQ+rahvwR+AOl2PqN1XdCJx2O45roaqVqrqj5+tzQDHd52YHDe3W2PPbyJ5ffs1JYZXwAUTkWyJSDrwH+E+347lGHwRWuR1EGMkCyi/4/QmCLMmEIhHJBaYDW9yNpP9ExCsiu4BqYI2q+vU1hFzCF5G1IrLvEr/uAFDVr6hqDvA48Cl3o720q72Gnud8Beig+3UEnL68BmOulYjEA88An73oE3xQUNVOVZ1G9yf12SLi1xKboydeOUFVF/XxqY/TffrWV/0YzoBc7TWIyAeAZcBCDdCbMP34ewgmFUDOBb/P7vkz44KeuvczwOOq+qzb8VwLVa0XkfXAUsBvN9NDboZ/JSKSf8Fv7wAOuBXLQInIUuCLwDtUtcnteMLMNiBfREaKSBRwH/BXl2MKSz03PH8DFKvqD92OZyBEJK13lZ2IDKJ7MYBfc1K4rdJ5BhhL9wqRY8DHVDWoZmgiUgZEA3U9f/RWEK40eifwEyANqAd2qerb3I2qb0TkNuAhwAv8VlW/5XJI/SYiTwA30d2hsQr4qqr+xtWg+klE5gGbgL10v58BvtxzbnZQEJEpwKN0/1vyAE+q6jf8OmY4JXxjjAlnYVXSMcaYcGYJ3xhjwoQlfGOMCROW8I0xJkxYwjfGmDBhCd8YY8KEJXxjjAkTlvBNQBGRzp7zCvb39An/goh4eh57o+e/udfSy11EviYi/zyA72u8wmN3ioiKyLiBxtWXcfrwvTf29LrvFJEjIvKFa43HhA5L+CbQNKvqNFWdSPdW81vp6Xekqjf4c2DpNtD3xP109zO/34chDcRQ4CkgRVVHqur/uByPCSCW8E3AUtVqYAXwqZ5kfOHM1ysiv+r5JLC6pxcJIvLenlOEdonIL3sOLUFEviIiJSKyme72GvT8eW7PCVaP0d20KkdE/iwi23uuveJqcfZ0bJwHfIju/joXXrv4MnH+R8+4m0XkiUt94rjca7mKB4C1QEMfnmvCjCV8E9BU9TDdvUbSL3ooH/hpzyeBemB5z0la9wJze1rOdgLvEZGZdCfiacBtwKxLXOtnqjpRVY8BH1TVmUAB8BkRSblKmHcAL6tqCVDXM96V4pwFLAem0v0J5h+Oebzca7lKHNDdo+j3QL2IvLsPzzdhJOTaI5uwcURVd/V8vR3IBZKAmcC27maKDKL7YIlk4Lne7qIicnGHy2MXHSv3mZ4Gb9DdDjmf/2tWdyn3Aw/3fP3Hnt9vv0KcqcBfVLUFaBGR5y9xzYWXeS2X1XP/4HvA24HXArV1tnGPJXwT0ERkFN2z24uTXesFX3fSnRAFeFRV/+2ia3z2KsOcv+C5NwGLgDmq2iQirwExV4gvGbgFmCwiSvenERWRf7lCnH1xyddyFR8Ffqiq6/vxPSaMWEnHBCwRSQN+Afy/Ps5W1wF3iUh6z/cni8gIYCNwp4gMku4Dr99+hWsMBs70JPtxwPVXGfMu4PeqOkJVc3tOUzsCzL/C97wOvF1EYnrq/8v68VoQkXUicqmjFWPovmlrzCVZwjeBZlDvsky6bz6uBr7el29U1SLg34HVIrIHWANk9hx2/SdgN91nAG+7wmVeBiJEpBj4Dt0HxV/J/cBzF/3ZM1xhtY6qbqP74JQ9PfHs5aKbrJd7LT2riPK49CHk3wcWS/dRkmtEJPMqsZswY/3wjXGBiMSraqOIxNL9CWRFzw+mq33fJLpvKn/+Ks97lO4DNV70TcQmFFgN3xh3rBSRCXSXYR7tS7IHUNV9wNWS/TIgju5PSMb8jc3wjTEmTFgN3xhjwoQlfGOMCROW8I0xJkxYwjfGmDBhCd8YY8KEJXxjjAkTlvCNMSZMWMI3xpgw8f8BJo4jaTsGKGwAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.12"
     }
-   ],
-   "source": [
-    "fig, ax = plt.subplots()\n",
-    "\n",
-    "ax.set_xlabel(r\"Dihedral Angle, $\\xi$\")\n",
-    "ax.set_ylabel(r\"$A(\\xi)$\")\n",
-    "\n",
-    "ax.plot(xi, A)\n",
-    "plt.gca()"
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "collapsed_sections": [],
-   "name": "Butane-FUNN.ipynb",
-   "provenance": []
   },
-  "jupytext": {
-   "formats": "ipynb,md",
-   "main_language": "python"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.12"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/examples/hoomd-blue/funn/Butane_FUNN.ipynb
+++ b/examples/hoomd-blue/funn/Butane_FUNN.ipynb
@@ -1,794 +1,789 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "T-Qkg9C9n7Cc"
-      },
-      "source": [
-        "# Setting up the environment\n",
-        "\n",
-        "First, we are setting up our environment. We use an already compiled and packaged installation of HOOMD-blue and the DLExt plugin.\n",
-        "We copy it from Google Drive and install PySAGES for it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "3eTbKklCnyd_"
-      },
-      "outputs": [],
-      "source": [
-        "%%bash\n",
-        "\n",
-        "BASE_URL=\"https://drive.google.com/u/0/uc?id=1hsKkKtdxZTVfHKgqVF6qV2e-4SShmhr7&export=download\"\n",
-        "wget -q --load-cookies /tmp/cookies.txt \"$BASE_URL&confirm=$(wget -q --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate $BASE_URL -O- | sed -rn 's/.*confirm=(\\w+).*/\\1\\n/p')\" -O pysages-env.zip\n",
-        "rm -rf /tmp/cookies.txt"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "KRPmkpd9n_NG",
-        "outputId": "286f58ca-9085-4d70-c151-acb90007cc30"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "env: PYSAGES_ENV=/env/pysages\n"
-          ]
-        }
-      ],
-      "source": [
-        "%env PYSAGES_ENV=/env/pysages"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "id": "J7OY5K9VoBBh"
-      },
-      "outputs": [],
-      "source": [
-        "%%bash\n",
-        "\n",
-        "mkdir -p $PYSAGES_ENV .\n",
-        "unzip -qquo pysages-env.zip -d $PYSAGES_ENV"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "id": "LlVSU_-FoD4w"
-      },
-      "outputs": [],
-      "source": [
-        "!update-alternatives --auto libcudnn &> /dev/null"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "id": "EMAWp8VloIk4"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "import sys\n",
-        "\n",
-        "ver = sys.version_info\n",
-        "sys.path.append(os.environ[\"PYSAGES_ENV\"] + \"/lib/python\" + str(ver.major) + \".\" + str(ver.minor) + \"/site-packages/\")\n",
-        "\n",
-        "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_strict_conv_algorithm_picker=false\"\n",
-        "os.environ[\"LD_LIBRARY_PATH\"] = \"/usr/lib/x86_64-linux-gnu:\" + os.environ[\"LD_LIBRARY_PATH\"]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "we_mTkFioS6R"
-      },
-      "source": [
-        "## PySAGES\n",
-        "\n",
-        "The next step is to install PySAGES.\n",
-        "First, we install the jaxlib version that matches the CUDA installation of this Colab setup. See the JAX documentation [here](https://github.com/google/jax) for more details."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "id": "vK0RZtbroQWe",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "23a64d4f-d270-40aa-8f16-6da6ef43cd0b"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%bash\n",
-        "\n",
-        "pip install -q --upgrade pip\n",
-        "# Installs the wheel compatible with CUDA 11 and cuDNN 8.0.5.\n",
-        "pip install -q --upgrade \"jax[cuda11_cudnn805]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wAtjM-IroYX8"
-      },
-      "source": [
-        "Now we can finally install PySAGES. We clone the newest version from [here](https://github.com/SSAGESLabs/PySAGES) and build the remaining pure python dependencies and PySAGES itself."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "id": "B-HB9CzioV5j"
-      },
-      "outputs": [],
-      "source": [
-        "%%bash\n",
-        "\n",
-        "rm -rf PySAGES\n",
-        "git clone https://github.com/SSAGESLabs/PySAGES.git &> /dev/null\n",
-        "cd PySAGES\n",
-        "pip install -q . &> /dev/null"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "id": "ppTzMmyyobHB",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "8eeee74c-53ae-4f6f-e280-51c729e7f395"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "mkdir: cannot create directory ‘/content/funn’: File exists\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%bash\n",
-        "\n",
-        "mkdir /content/funn\n",
-        "cd /content/funn"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KBFVcG1FoeMq"
-      },
-      "source": [
-        "# FUNN-biased simulations"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0W2ukJuuojAl"
-      },
-      "source": [
-        "FUNN gradually learns the free energy gradient from a discrete estimate based on the same algorithm as the ABF method, but employs a neural network to provide a continuous approximation to it.\n",
-        "\n",
-        "For this Colab, we are using butane as the example molecule."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "id": "BBvC7Spoog82"
-      },
-      "outputs": [],
-      "source": [
-        "import hoomd\n",
-        "import hoomd.md\n",
-        "\n",
-        "import numpy\n",
-        "\n",
-        "\n",
-        "pi = numpy.pi\n",
-        "kT = 0.596161\n",
-        "dt = 0.02045\n",
-        "mode = \"--mode=gpu\"\n",
-        "\n",
-        "\n",
-        "def generate_context(kT = kT, dt = dt, mode = mode):\n",
-        "    \"\"\"\n",
-        "    Generates a simulation context, we pass this function to the attribute\n",
-        "    `run` of our sampling method.\n",
-        "    \"\"\"\n",
-        "    hoomd.context.initialize(mode)\n",
-        "\n",
-        "    ### System Definition\n",
-        "    snapshot = hoomd.data.make_snapshot(\n",
-        "        N = 14,\n",
-        "        box = hoomd.data.boxdim(Lx = 41, Ly = 41, Lz = 41),\n",
-        "        particle_types = ['C', 'H'],\n",
-        "        bond_types = [\"CC\", \"CH\"],\n",
-        "        angle_types = [\"CCC\", \"CCH\", \"HCH\"],\n",
-        "        dihedral_types = [\"CCCC\", \"HCCC\", \"HCCH\"],\n",
-        "        pair_types = [\"CCCC\", \"HCCC\", \"HCCH\"],\n",
-        "        dtype = \"double\"\n",
-        "    )\n",
-        "\n",
-        "    snapshot.particles.typeid[0] = 0\n",
-        "    snapshot.particles.typeid[1:4] = 1\n",
-        "    snapshot.particles.typeid[4] = 0\n",
-        "    snapshot.particles.typeid[5:7] = 1\n",
-        "    snapshot.particles.typeid[7] = 0\n",
-        "    snapshot.particles.typeid[8:10] = 1\n",
-        "    snapshot.particles.typeid[10] = 0\n",
-        "    snapshot.particles.typeid[11:14] = 1\n",
-        "\n",
-        "    positions = numpy.array([\n",
-        "        [-2.990196,  0.097881,  0.000091],\n",
-        "        [-2.634894, -0.911406,  0.001002],\n",
-        "        [-2.632173,  0.601251, -0.873601],\n",
-        "        [-4.060195,  0.099327, -0.000736],\n",
-        "        [-2.476854,  0.823942,  1.257436],\n",
-        "        [-2.832157,  1.833228,  1.256526],\n",
-        "        [-2.834877,  0.320572,  2.131128],\n",
-        "        [-0.936856,  0.821861,  1.258628],\n",
-        "        [-0.578833,  1.325231,  0.384935],\n",
-        "        [-0.581553, -0.187426,  1.259538],\n",
-        "        [-0.423514,  1.547922,  2.515972],\n",
-        "        [-0.781537,  1.044552,  3.389664],\n",
-        "        [ 0.646485,  1.546476,  2.516800],\n",
-        "        [-0.778816,  2.557208,  2.515062]\n",
-        "    ])\n",
-        "\n",
-        "    reference_box_low_coords = numpy.array([-22.206855, -19.677099, -19.241968])\n",
-        "    box_low_coords = numpy.array([\n",
-        "        -snapshot.box.Lx / 2,\n",
-        "        -snapshot.box.Ly / 2,\n",
-        "        -snapshot.box.Lz / 2\n",
-        "    ])\n",
-        "    positions += (box_low_coords - reference_box_low_coords)\n",
-        "\n",
-        "    snapshot.particles.position[:] = positions[:]\n",
-        "\n",
-        "    mC = 12.00\n",
-        "    mH = 1.008\n",
-        "    snapshot.particles.mass[:] = [\n",
-        "        mC, mH, mH, mH,\n",
-        "        mC, mH, mH,\n",
-        "        mC, mH, mH,\n",
-        "        mC, mH, mH, mH\n",
-        "    ]\n",
-        "\n",
-        "    reference_charges = numpy.array([\n",
-        "        -0.180000, 0.060000, 0.060000, 0.060000,\n",
-        "        -0.120000, 0.060000, 0.060000,\n",
-        "        -0.120000, 0.060000, 0.060000,\n",
-        "        -0.180000, 0.060000, 0.060000, 0.060000]\n",
-        "    )\n",
-        "    charge_conversion = 18.22262\n",
-        "    snapshot.particles.charge[:] = charge_conversion * reference_charges[:]\n",
-        "\n",
-        "    snapshot.bonds.resize(13)\n",
-        "    snapshot.bonds.typeid[0:3] = 1\n",
-        "    snapshot.bonds.typeid[3] = 0\n",
-        "    snapshot.bonds.typeid[4:6] = 1\n",
-        "    snapshot.bonds.typeid[6] = 0\n",
-        "    snapshot.bonds.typeid[7:9] = 1\n",
-        "    snapshot.bonds.typeid[9] = 0\n",
-        "    snapshot.bonds.typeid[10:13] = 1\n",
-        "\n",
-        "    snapshot.bonds.group[:] = [\n",
-        "        [0, 2], [0, 1], [0, 3], [0, 4],\n",
-        "        [4, 5], [4, 6], [4, 7],\n",
-        "        [7, 8], [7, 9], [7, 10],\n",
-        "        [10, 11], [10, 12], [10, 13]\n",
-        "    ]\n",
-        "\n",
-        "    snapshot.angles.resize(24)\n",
-        "    snapshot.angles.typeid[0:2] = 2\n",
-        "    snapshot.angles.typeid[2] = 1\n",
-        "    snapshot.angles.typeid[3] = 2\n",
-        "    snapshot.angles.typeid[4:8] = 1\n",
-        "    snapshot.angles.typeid[8] = 0\n",
-        "    snapshot.angles.typeid[9] = 2\n",
-        "    snapshot.angles.typeid[10:14] = 1\n",
-        "    snapshot.angles.typeid[14] = 0\n",
-        "    snapshot.angles.typeid[15] = 2\n",
-        "    snapshot.angles.typeid[16:21] = 1\n",
-        "    snapshot.angles.typeid[21:24] = 2\n",
-        "\n",
-        "    snapshot.angles.group[:] = [\n",
-        "        [1, 0, 2], [2, 0, 3], [2, 0, 4],\n",
-        "        [1, 0, 3], [1, 0, 4], [3, 0, 4],\n",
-        "        [0, 4, 5], [0, 4, 6], [0, 4, 7],\n",
-        "        [5, 4, 6], [5, 4, 7], [6, 4, 7],\n",
-        "        [4, 7, 8], [4, 7, 9], [4, 7, 10],\n",
-        "        [8, 7, 9], [8, 7, 10], [9, 7, 10],\n",
-        "        [7, 10, 11], [7, 10, 12], [7, 10, 13],\n",
-        "        [11, 10, 12], [11, 10, 13], [12, 10, 13]\n",
-        "    ]\n",
-        "\n",
-        "    snapshot.dihedrals.resize(27)\n",
-        "    snapshot.dihedrals.typeid[0:2] = 2\n",
-        "    snapshot.dihedrals.typeid[2] = 1\n",
-        "    snapshot.dihedrals.typeid[3:5] = 2\n",
-        "    snapshot.dihedrals.typeid[5] = 1\n",
-        "    snapshot.dihedrals.typeid[6:8] = 2\n",
-        "    snapshot.dihedrals.typeid[8:11] = 1\n",
-        "    snapshot.dihedrals.typeid[11] = 0\n",
-        "    snapshot.dihedrals.typeid[12:14] = 2\n",
-        "    snapshot.dihedrals.typeid[14] = 1\n",
-        "    snapshot.dihedrals.typeid[15:17] = 2\n",
-        "    snapshot.dihedrals.typeid[17:21] = 1\n",
-        "    snapshot.dihedrals.typeid[21:27] = 2\n",
-        "\n",
-        "    snapshot.dihedrals.group[:] = [\n",
-        "        [2, 0, 4, 5], [2, 0, 4, 6], [2, 0, 4, 7],\n",
-        "        [1, 0, 4, 5], [1, 0, 4, 6], [1, 0, 4, 7],\n",
-        "        [3, 0, 4, 5], [3, 0, 4, 6], [3, 0, 4, 7],\n",
-        "        [0, 4, 7, 8], [0, 4, 7, 9], [0, 4, 7, 10],\n",
-        "        [5, 4, 7, 8], [5, 4, 7, 9], [5, 4, 7, 10],\n",
-        "        [6, 4, 7, 8], [6, 4, 7, 9], [6, 4, 7, 10],\n",
-        "        [4, 7, 10, 11], [4, 7, 10, 12], [4, 7, 10, 13],\n",
-        "        [8, 7, 10, 11], [8, 7, 10, 12], [8, 7, 10, 13],\n",
-        "        [9, 7, 10, 11], [9, 7, 10, 12], [9, 7, 10, 13]\n",
-        "    ]\n",
-        "\n",
-        "    snapshot.pairs.resize(27)\n",
-        "    snapshot.pairs.typeid[0:1] = 0\n",
-        "    snapshot.pairs.typeid[1:11] = 1\n",
-        "    snapshot.pairs.typeid[11:27] = 2\n",
-        "    snapshot.pairs.group[:] = [\n",
-        "        # CCCC\n",
-        "        [0, 10],\n",
-        "        # HCCC\n",
-        "        [0, 8], [0, 9], [5, 10], [6, 10],\n",
-        "        [1, 7], [2, 7], [3, 7],\n",
-        "        [11, 4], [12, 4], [13, 4],\n",
-        "        # HCCH\n",
-        "        [1, 5], [1, 6], [2, 5], [2, 6], [3, 5], [3, 6],\n",
-        "        [5, 8], [6, 8], [5, 9], [6, 9],\n",
-        "        [8, 11], [8, 12], [8, 13], [9, 11], [9, 12], [9, 13]\n",
-        "    ]\n",
-        "\n",
-        "    hoomd.init.read_snapshot(snapshot)\n",
-        "\n",
-        "    ### Set interactions\n",
-        "    nl_ex = hoomd.md.nlist.cell()\n",
-        "    nl_ex.reset_exclusions(exclusions = [\"1-2\", \"1-3\", \"1-4\"])\n",
-        "\n",
-        "    lj = hoomd.md.pair.lj(r_cut = 12.0, nlist = nl_ex)\n",
-        "    lj.pair_coeff.set('C', 'C', epsilon = 0.07, sigma = 3.55)\n",
-        "    lj.pair_coeff.set('H', 'H', epsilon = 0.03, sigma = 2.42)\n",
-        "    lj.pair_coeff.set('C', 'H', epsilon = numpy.sqrt(0.07*0.03), sigma = numpy.sqrt(3.55*2.42))\n",
-        "\n",
-        "    coulomb = hoomd.md.charge.pppm(hoomd.group.charged(), nlist = nl_ex)\n",
-        "    coulomb.set_params(Nx = 64, Ny = 64, Nz = 64, order = 6, rcut = 12.0)\n",
-        "\n",
-        "    harmonic = hoomd.md.bond.harmonic()\n",
-        "    harmonic.bond_coeff.set(\"CC\", k = 2*268.0, r0 = 1.529)\n",
-        "    harmonic.bond_coeff.set(\"CH\", k = 2*340.0, r0 = 1.09)\n",
-        "\n",
-        "    angle = hoomd.md.angle.harmonic()\n",
-        "    angle.angle_coeff.set(\"CCC\", k = 2*58.35, t0 = 112.7 * pi / 180)\n",
-        "    angle.angle_coeff.set(\"CCH\", k = 2*37.5, t0 = 110.7 * pi / 180)\n",
-        "    angle.angle_coeff.set(\"HCH\", k = 2*33.0, t0 = 107.8 * pi / 180)\n",
-        "\n",
-        "\n",
-        "    dihedral = hoomd.md.dihedral.opls()\n",
-        "    dihedral.dihedral_coeff.set(\"CCCC\", k1 = 1.3, k2 = -0.05, k3 = 0.2, k4 = 0.0)\n",
-        "    dihedral.dihedral_coeff.set(\"HCCC\", k1 = 0.0, k2 = 0.0, k3 = 0.3, k4 = 0.0)\n",
-        "    dihedral.dihedral_coeff.set(\"HCCH\", k1 = 0.0, k2 = 0.0, k3 = 0.3, k4 = 0.0)\n",
-        "\n",
-        "    lj_special_pairs = hoomd.md.special_pair.lj()\n",
-        "    lj_special_pairs.pair_coeff.set(\"CCCC\", epsilon = 0.07, sigma = 3.55, r_cut = 12.0)\n",
-        "    lj_special_pairs.pair_coeff.set(\"HCCH\", epsilon = 0.03, sigma = 2.42, r_cut = 12.0)\n",
-        "    lj_special_pairs.pair_coeff.set(\"HCCC\",\n",
-        "        epsilon = numpy.sqrt(0.07 * 0.03), sigma = numpy.sqrt(3.55 * 2.42), r_cut = 12.0\n",
-        "    )\n",
-        "\n",
-        "    coulomb_special_pairs = hoomd.md.special_pair.coulomb()\n",
-        "    coulomb_special_pairs.pair_coeff.set(\"CCCC\", alpha = 0.5, r_cut = 12.0)\n",
-        "    coulomb_special_pairs.pair_coeff.set(\"HCCC\", alpha = 0.5, r_cut = 12.0)\n",
-        "    coulomb_special_pairs.pair_coeff.set(\"HCCH\", alpha = 0.5, r_cut = 12.0)\n",
-        "\n",
-        "    hoomd.md.integrate.mode_standard(dt = dt)\n",
-        "    integrator = hoomd.md.integrate.nvt(group = hoomd.group.all(), kT = kT, tau = 100*dt)\n",
-        "    integrator.randomize_velocities(seed = 42)\n",
-        "\n",
-        "    return hoomd.context.current"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3UrzENm_oo6U"
-      },
-      "source": [
-        "Next, we load PySAGES and the relevant classes and methods for our problem"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "id": "fpMg-o8WomAA"
-      },
-      "outputs": [],
-      "source": [
-        "from pysages.grids import Grid\n",
-        "from pysages.colvars import DihedralAngle\n",
-        "from pysages.methods import FUNN\n",
-        "\n",
-        "import pysages"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "LknkRvo1o4av"
-      },
-      "source": [
-        "The next step is to define the collective variable (CV). In this case, we choose the central dihedral angle.\n",
-        "\n",
-        "We also define a grid to bin our CV space, the topology (tuple indicating the number of\n",
-        "nodes of each hidden layer) for our neural network which will model the free energy.\n",
-        "\n",
-        "The appropriate number of bins depends on the complexity of the free energy landscape,\n",
-        "a good rule of thumb is to choose between 20 to 100 bins along each CV dimension\n",
-        "(using higher values for more rugged free energy surfaces), but it can be systematically\n",
-        "found trying different values for short runs of any given system."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "id": "B1Z8FWz0o7u_"
-      },
-      "outputs": [],
-      "source": [
-        "cvs = [DihedralAngle([0, 4, 7, 10])]\n",
-        "grid = Grid(lower=(-pi,), upper=(pi,), shape=(64,), periodic=True)\n",
-        "\n",
-        "topology = (14,)\n",
-        "method = FUNN(cvs, grid, topology)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Fz8BfU34pA_N"
-      },
-      "source": [
-        "We now simulate $5\\times10^5$ time steps.\n",
-        "Make sure to run with GPU support, otherwise, it can take a very long time."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "K951m4BbpUar",
-        "outputId": "0e9eb82c-21cf-4048-a83d-ad246dc05ebe"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "HOOMD-blue v2.9.7 CUDA (11.1) DOUBLE HPMC_MIXED SSE SSE2 \n",
-            "Compiled: 07/07/2022\n",
-            "Copyright (c) 2009-2019 The Regents of the University of Michigan.\n",
-            "-----\n",
-            "You are using HOOMD-blue. Please cite the following:\n",
-            "* J A Anderson, J Glaser, and S C Glotzer. \"HOOMD-blue: A Python package for\n",
-            "  high-performance molecular dynamics and hard particle Monte Carlo\n",
-            "  simulations\", Computational Materials Science 173 (2020) 109363\n",
-            "-----\n",
-            "HOOMD-blue is running on the following GPU(s):\n",
-            " [0]              Tesla T4  40 SM_7.5 @ 1.59 GHz, 15109 MiB DRAM, MNG\n",
-            "notice(2): Group \"all\" created containing 14 particles\n",
-            "notice(2): -- Neighborlist exclusion statistics -- :\n",
-            "notice(2): Particles with 7 exclusions             : 6\n",
-            "notice(2): Particles with 10 exclusions             : 6\n",
-            "notice(2): Particles with 13 exclusions             : 2\n",
-            "notice(2): Neighbors included by diameter          : no\n",
-            "notice(2): Neighbors excluded when in the same body: no\n",
-            "notice(2): Group \"charged\" created containing 14 particles\n",
-            "-----\n",
-            "You are using PPPM. Please cite the following:\n",
-            "* D N LeBard, B G Levine, S A Barr, A Jusufi, S Sanders, M L Klein, and A Z\n",
-            "  Panagiotopoulos. \"Self-assembly of coarse-grained ionic surfactants\n",
-            "  accelerated by graphics processing units\", Journal of Computational Physics 8\n",
-            "  (2012) 2385-2397\n",
-            "-----\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/pysages/ml/utils.py:54: FutureWarning: jax.tree_flatten is deprecated, and will be removed in a future release. Use jax.tree_util.tree_flatten instead.\n",
-            "  data, structure = tree_flatten(params)\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "** starting run **\n",
-            "notice(2): charge.pppm: RMS error: 1.29239e-08\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
-            "  dp = solve(H, Je, sym_pos=True)\n",
-            "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
-            "  dp = solve(H, Je, sym_pos=True)\n",
-            "/usr/local/lib/python3.7/dist-packages/pysages/methods/funn.py:191: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
-            "  Wp = linalg.solve(Jxi @ Jxi.T, Jxi @ p, sym_pos=\"sym\")\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Time 00:00:15 | Step 2382 / 500000 | TPS 238.192 | ETA 00:34:49\n",
-            "Time 00:00:25 | Step 9800 / 500000 | TPS 741.731 | ETA 00:11:00\n",
-            "Time 00:00:35 | Step 16594 / 500000 | TPS 679.375 | ETA 00:11:51\n",
-            "Time 00:00:45 | Step 23699 / 500000 | TPS 710.482 | ETA 00:11:10\n",
-            "Time 00:00:55 | Step 30685 / 500000 | TPS 698.565 | ETA 00:11:11\n",
-            "Time 00:01:05 | Step 38038 / 500000 | TPS 735.282 | ETA 00:10:28\n",
-            "Time 00:01:15 | Step 44802 / 500000 | TPS 676.339 | ETA 00:11:13\n",
-            "Time 00:01:25 | Step 51935 / 500000 | TPS 713.242 | ETA 00:10:28\n",
-            "Time 00:01:35 | Step 59345 / 500000 | TPS 740.912 | ETA 00:09:54\n",
-            "Time 00:01:45 | Step 66486 / 500000 | TPS 714.031 | ETA 00:10:07\n",
-            "Time 00:01:55 | Step 73877 / 500000 | TPS 739.073 | ETA 00:09:36\n",
-            "Time 00:02:05 | Step 81221 / 500000 | TPS 734.045 | ETA 00:09:30\n",
-            "Time 00:02:15 | Step 88551 / 500000 | TPS 732.972 | ETA 00:09:21\n",
-            "Time 00:02:25 | Step 95662 / 500000 | TPS 711.075 | ETA 00:09:28\n",
-            "Time 00:02:35 | Step 102927 / 500000 | TPS 726.454 | ETA 00:09:06\n",
-            "Time 00:02:45 | Step 110189 / 500000 | TPS 726.175 | ETA 00:08:56\n",
-            "Time 00:02:55 | Step 117219 / 500000 | TPS 702.939 | ETA 00:09:04\n",
-            "Time 00:03:05 | Step 124386 / 500000 | TPS 716.627 | ETA 00:08:44\n",
-            "Time 00:03:15 | Step 131649 / 500000 | TPS 726.238 | ETA 00:08:27\n",
-            "Time 00:03:25 | Step 138980 / 500000 | TPS 733.08 | ETA 00:08:12\n",
-            "Time 00:03:35 | Step 146259 / 500000 | TPS 727.83 | ETA 00:08:06\n",
-            "Time 00:03:45 | Step 153598 / 500000 | TPS 733.834 | ETA 00:07:52\n",
-            "Time 00:03:55 | Step 160870 / 500000 | TPS 727.165 | ETA 00:07:46\n",
-            "Time 00:04:05 | Step 168150 / 500000 | TPS 727.977 | ETA 00:07:35\n",
-            "Time 00:04:15 | Step 175412 / 500000 | TPS 726.142 | ETA 00:07:27\n",
-            "Time 00:04:25 | Step 182753 / 500000 | TPS 734.066 | ETA 00:07:12\n",
-            "Time 00:04:35 | Step 190001 / 500000 | TPS 721.559 | ETA 00:07:09\n",
-            "Time 00:04:45 | Step 197404 / 500000 | TPS 740.255 | ETA 00:06:48\n",
-            "Time 00:04:55 | Step 204713 / 500000 | TPS 730.888 | ETA 00:06:44\n",
-            "Time 00:05:05 | Step 212053 / 500000 | TPS 733.967 | ETA 00:06:32\n",
-            "Time 00:05:15 | Step 219418 / 500000 | TPS 736.472 | ETA 00:06:20\n",
-            "Time 00:05:25 | Step 226762 / 500000 | TPS 734.326 | ETA 00:06:12\n",
-            "Time 00:05:35 | Step 233828 / 500000 | TPS 706.592 | ETA 00:06:16\n",
-            "Time 00:05:45 | Step 240993 / 500000 | TPS 716.425 | ETA 00:06:01\n",
-            "Time 00:05:55 | Step 248322 / 500000 | TPS 732.826 | ETA 00:05:43\n",
-            "Time 00:06:05 | Step 255645 / 500000 | TPS 732.213 | ETA 00:05:33\n",
-            "Time 00:06:15 | Step 263035 / 500000 | TPS 738.913 | ETA 00:05:20\n",
-            "Time 00:06:25 | Step 270349 / 500000 | TPS 731.387 | ETA 00:05:13\n",
-            "Time 00:06:35 | Step 277694 / 500000 | TPS 734.447 | ETA 00:05:02\n",
-            "Time 00:06:45 | Step 285001 / 500000 | TPS 730.286 | ETA 00:04:54\n",
-            "Time 00:06:55 | Step 292333 / 500000 | TPS 733.145 | ETA 00:04:43\n",
-            "Time 00:07:05 | Step 299675 / 500000 | TPS 734.125 | ETA 00:04:32\n",
-            "Time 00:07:15 | Step 307066 / 500000 | TPS 739.064 | ETA 00:04:21\n",
-            "Time 00:07:25 | Step 314514 / 500000 | TPS 744.769 | ETA 00:04:09\n",
-            "Time 00:07:35 | Step 321962 / 500000 | TPS 744.749 | ETA 00:03:59\n",
-            "Time 00:07:45 | Step 329389 / 500000 | TPS 742.647 | ETA 00:03:49\n",
-            "Time 00:07:55 | Step 336764 / 500000 | TPS 737.498 | ETA 00:03:41\n",
-            "Time 00:08:05 | Step 344194 / 500000 | TPS 742.825 | ETA 00:03:29\n",
-            "Time 00:08:15 | Step 351001 / 500000 | TPS 680.669 | ETA 00:03:38\n",
-            "Time 00:08:25 | Step 358207 / 500000 | TPS 720.552 | ETA 00:03:16\n",
-            "Time 00:08:35 | Step 365515 / 500000 | TPS 730.713 | ETA 00:03:04\n",
-            "Time 00:08:45 | Step 372786 / 500000 | TPS 727.084 | ETA 00:02:54\n",
-            "Time 00:08:55 | Step 380039 / 500000 | TPS 725.232 | ETA 00:02:45\n",
-            "Time 00:09:05 | Step 387469 / 500000 | TPS 742.9 | ETA 00:02:31\n",
-            "Time 00:09:15 | Step 394910 / 500000 | TPS 744.028 | ETA 00:02:21\n",
-            "Time 00:09:25 | Step 402050 / 500000 | TPS 713.989 | ETA 00:02:17\n",
-            "Time 00:09:35 | Step 409480 / 500000 | TPS 742.954 | ETA 00:02:01\n",
-            "Time 00:09:45 | Step 416909 / 500000 | TPS 742.893 | ETA 00:01:51\n",
-            "Time 00:09:55 | Step 424338 / 500000 | TPS 742.894 | ETA 00:01:41\n",
-            "Time 00:10:05 | Step 431758 / 500000 | TPS 741.955 | ETA 00:01:31\n",
-            "Time 00:10:15 | Step 439226 / 500000 | TPS 746.72 | ETA 00:01:21\n",
-            "Time 00:10:25 | Step 446648 / 500000 | TPS 742.13 | ETA 00:01:11\n",
-            "Time 00:10:35 | Step 454097 / 500000 | TPS 744.802 | ETA 00:01:01\n",
-            "Time 00:10:45 | Step 461493 / 500000 | TPS 739.54 | ETA 00:00:52\n",
-            "Time 00:10:55 | Step 468989 / 500000 | TPS 749.58 | ETA 00:00:41\n",
-            "Time 00:11:05 | Step 476190 / 500000 | TPS 720.017 | ETA 00:00:33\n",
-            "Time 00:11:15 | Step 483637 / 500000 | TPS 744.693 | ETA 00:00:21\n",
-            "Time 00:11:25 | Step 491091 / 500000 | TPS 745.319 | ETA 00:00:11\n",
-            "Time 00:11:35 | Step 498561 / 500000 | TPS 746.975 | ETA 00:00:01\n",
-            "Time 00:11:37 | Step 500000 / 500000 | TPS 742.668 | ETA 00:00:00\n",
-            "Average TPS: 722.503\n",
-            "---------\n",
-            "-- Neighborlist stats:\n",
-            "82696 normal updates / 1667 forced updates / 0 dangerous updates\n",
-            "n_neigh_min: 0 / n_neigh_max: 6 / n_neigh_avg: 3.85714\n",
-            "shortest rebuild period: 3\n",
-            "-- Cell list stats:\n",
-            "Dimension: 3, 3, 3\n",
-            "n_min    : 0 / n_max: 14 / n_avg: 0.518519\n",
-            "** run complete **\n"
-          ]
-        }
-      ],
-      "source": [
-        "run_result = pysages.run(method, generate_context, int(5e5))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "PXBKUfK0p9T2"
-      },
-      "source": [
-        "Since the neural network learns the gradient of the free energy, we need a separate way of integrating it to find the free energy surface. Let's plot first the gradient of the free energy."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {
-        "id": "X69d1R7OpW4P"
-      },
-      "outputs": [],
-      "source": [
-        "import matplotlib.pyplot as plt"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "result = pysages.analyze(run_result)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "55W8QRe7h666",
-        "outputId": "690a8583-f7e8-47ab-adfb-52afd179160d"
-      },
-      "execution_count": 14,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/pysages/ml/utils.py:54: FutureWarning: jax.tree_flatten is deprecated, and will be removed in a future release. Use jax.tree_util.tree_flatten instead.\n",
-            "  data, structure = tree_flatten(params)\n",
-            "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
-            "  dp = solve(H, Je, sym_pos=True)\n",
-            "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
-            "  dp = solve(H, Je, sym_pos=True)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "mesh = result[\"mesh\"]\n",
-        "A = result[\"free_energy\"]"
-      ],
-      "metadata": {
-        "id": "QZObNpLTh9JY"
-      },
-      "execution_count": 15,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 303
-        },
-        "id": "TBiPAnMwqEIF",
-        "outputId": "6ae55c65-5f08-42a5-d48e-11772b318f96"
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<matplotlib.axes._subplots.AxesSubplot at 0x7f07042f45d0>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 16
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEMCAYAAADHxQ0LAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3xcd5Xw/88ZdcuSbfXiIlly77biHsd24lTHDiRAQkJdSHgCAXZhgV1gl4Vll11+LGR5gBAIhBQSAunNaU5xj+Uud1u2rGoVW9Xqc35/zCiPMS6SNTN3ynm/Xn5ZZXS/Z2Tr6M65556vqCrGGGPCn8vpAIwxxgSGJXxjjIkQlvCNMSZCWMI3xpgIYQnfGGMihCV8Y4yJEAFL+CIyQUR2nvWnWUS+Gqj1jTEm0okTffgiEgVUAvNUtexCj0tLS9O8vLyAxWWMMaFu27Zt9aqafr7PRQc6GK+rgaMXS/YAeXl5FBcXBygkY4wJfSJywbzqVA3/duCJ831CRO4WkWIRKa6rqwtwWMYYE74CnvBFJBZYBfz5fJ9X1QdVtUhVi9LTz/uqxBhjzGVw4gz/BmC7qp50YG1jjIlYTiT8O7hAOccYY4z/BDThi0gisAJ4JpDrGmOMCXCXjqq2AamBXNMYY4yH3WlrjDERwqk+fGNCUmdPL5Wn26k43U756TOowseuGEVMlJ07meBnCd+Yfjh8soV7Ht1GaX3b33xuc2kD998+iyiXOBCZMf1nCd+YS2jp6OaeR7fR3NHN318znpEjEhiVMoSRIxJ4cVcV//nqARJjo/nRrdMQsaRvgpclfGMuQlX5+p93UXbqDI9/bh7zx/51z8E9VxXQ1tnD/649QmJcNN9dOcmSvglalvCNuYgH3i3ltb0n+c5Nk/4m2ff5+xXjaens4XcbjpEUH83frxgf4CiN6R9L+MZcwIYj9fz4tQOsnJ7N3y3Ov+DjRITv3jSZts4e7n/rMEnx0XzuyrEBjNSY/rHWAmPOo7Kxnfue2EFB+lD+69bplyzTuFzCf354OjdMzeI/XtnPiYYzAYrUmP6zhG/MOdxu5d7Ht9PV4+aBT8whMa5/L4SjXML3Vk0hyiX8dn2pn6M0ZuAs4RtzjrUHatlV3sj3Vk2hIH3ogL42MzmeD83K5anichpaO/0UoTGXxxK+Mef4/cZjZCXHs3pmzmV9/d1LxtLR7eaRTRfd38eYgLOEb8xZDta0sOFIA59cOOay754tzEjimkmZPLLpOGe6enwboDGDYAnfmLP8fsMx4mNc3HHF6EEd5wtXjeX0mW6e2lruo8iMGTxL+MZ4nWrr4tkdlXxo1khGJMYO6lhFeSkUjRnBb9Ydo6fX7aMIjRkcS/jGeD3x/gk6e9x8ZlGeT453z1UFVDa28/Keap8cz5jBsoRvDNDd6+aRTce5clwa4zOTfHLMqydmUJCeyK/fLUVVfXJMYwbDEr4xwCt7qjnZ3Omzs3vw3Ix1z5IC9lU3s/5Ivc+Oa8zlsoRvDPD7DcfJT0tk6fgMnx539awcMpLi+M26Yz49rjGXwxK+iXjbT5xmZ3kjn16Yh8vHM+3joqP4SNFINhyp51Rbl0+PbcxAWcI3Ee/3G46TFBfNrXNG+uX4N0zNptetvLGvxi/HN6a/LOGbiNba2cNre2v48OxchvZzZs5ATclJZuSIBNaUWMI3zgpowheR4SLyFxE5ICL7RWRBINc35lzvHKylq8fNjdOy/baGiHDD1CzWH6mnuaPbb+sYcymBPsO/H1ijqhOBGcD+AK9vzF9ZU1JD2tBYivJS/LrO9VOz6e5V1u6v9es6xlxMwBK+iAwDlgAPAahql6o2Bmp9Y87V0d3L2wdqWTE5y+8bkM8aNZzM5DheLbGbsIxzAnmGnw/UAb8XkR0i8lsRSTz3QSJyt4gUi0hxXV1dAMMzkWb94Xraunq5fmqW39dyuYTrpmTx7qE6G6hmHBPIhB8NzAZ+paqzgDbgW+c+SFUfVNUiVS1KT08PYHgm0qzZW0NSfDQLLrBXra9dPzWLjm437x60ExnjjEAm/AqgQlW3eN//C55fAMYEXHevmzf2nWTFpExiowPzYzA3L4WUxFhetW4d45CAJXxVrQHKRWSC90NXA/sCtb4xZ9tSeoqm9m6uC0A5p090lIsVkzJZe6CWzp7egK1rTJ9Ad+ncBzwuIruBmcB/BHh9YwBYs7eahJgolowLbNnw+mlZtHb2sP6wzdYxgeefO00uQFV3AkWBXNOYc7ndymt7T7JsYjoJsVEBXXtRQRpJ8dG8WlLD1ZMyA7q2MXanrYk420+cpq6lk+umBK6c0yc22sU1kzJ5c/9Jum1jFBNglvBNxFlTUkNslIvlE307GbO/rp+aReOZbraUnnJkfRO5LOGbiKKqrNlbw+JxaSTFxzgSw5Jx6STERLFmr92EZQLLEr6JKHurmqk43c71DpRz+iTERrGoMJV1duHWBJglfBNR1pTUEOUSrpns7AXTRYVplDWcofzUGUfjMJHFEr6JKGsP1FI0ZgQpibGOxrG4MA2ADbb1oQkgS/gmYtS1dLKvupkl450f2VGYMZSMpDjb69YElCV8EzE2HvUk1yvHpTkciWdG/uLCNDYebcDtVqfDMRHCEr6JGO8dqmfEkBim5AxzOhQAFo9L41RbF/trmp0OxUQIS/gmIqgq6w7Xsagwze+z7/trkdXxTYBZwjcR4dDJVmpbOoOinNMnMzmecRlDrT3TBIwlfBMR1h32zKBfHOBhaZeyqDCNrcdP0dFt0zON/1nCNxFh3eF6CtITyR2e4HQof2VxYRod3W62nzjtdCgmAljCN2Gvo7uXLccauDLIzu4B5o1NIcolVsc3AWEJ34S97WWn6eh2B1X9vk9SfAyzRg1n/ZEGp0MxEcASvgl77x2uJ9olzAvQ3rUDtagwjT0VjTSd6XY6FBPmLOGbsLfucB2zx4xgaFxA9/vpt8Xj0nArbCq1so7xL0v4Jqw1tHayt6qZJUFYzukzc9RwEmOjbMyC8TtL+Cas9SXRYGvHPFtMlIt5Y1PZYHV842eW8E1YW3e4nmEJMUzLDY5xCheyuDCNY/VtVJy2ccnGfwKa8EXkuIjsEZGdIlIcyLVN5FFV1h+uZ3EQjVO4kMXjbMyC8T8nzvCXqepMVS1yYG0TQY7UtlLT3PFBMg1m4zKGkjY01va5NX5lJR0Ttt7zzqjp22wkmIkIc/NT2HLMEr7xn0AnfAVeF5FtInL3+R4gIneLSLGIFNfV1QU4PBNONh1tYEzqEEalDHE6lH6Zm5dCZWO71fGN3wQ64S9W1dnADcAXRWTJuQ9Q1QdVtUhVi9LTg7ezwgS3Xrey5VgDC4L0ZqvzmZvvifV9O8s3fhLQhK+qld6/a4FngbmBXN9Ejv3VzbR09DA/hBL+xKwkkuOjLeEbvwlYwheRRBFJ6nsbuBYoCdT6JrJsLvX0tIdSwne5rI5v/CuQZ/iZwHoR2QW8D7ysqmsCuL6JIJuONpCflkjWsHinQxmQufkpHKtvo7a5w+lQTBgK2HARVS0FZgRqPRO5et3K+8dOsXJGttOhDNi8vjr+8VOsnJ7jcDQm3Fhbpgk7e6uaaOkMrfp9nyk5ySTGRlk/vvELS/gm7PTV70OpQ6dPdJSLOXkpduHW+IUlfBN2NpeeYmx6IhnJoVW/7zMvP4WDJ1s43dbldCgmzFjCN2Glp9fN+8dOhWQ5p8/c/BTAU8c3xpcs4ZuwsreqmdYQrd/3mT5yGHHRLivrGJ+zhG/CyqYP+u9THI7k8sVFRzFr9HBL+MbnLOGbsLK5tIGC9EQykkKzft9nbn4qe6uaaO6wfW6N71jCN2Gjp9fN1mOnWFAQuuWcPvPzU3ArbCs77XQoJoxYwjdhY09lE21dvSFdv+8za/QIol1iZR3jU5bwTdjY7L1Zqe9u1VCWEBvF9JHD2FJq+9wa37GEb8LG5tIGxmUMJT0pzulQfGLe2FR2VzTR3tXrdCgmTFjCN2Ghu9fN1uOh3X9/rrn5KfS4le0nrI5vfMMSvgkLeyqbOBMm9fs+c8aMwCW2IYrxHUv4Jiz0zc+ZF8L99+dKjo9hck6yJXzjM5bwTVjYXHqK8ZlDSRsaHvX7PnPzUtl+4jRdPW6nQzFhwBK+CXndvW6Kj58Ki+6cc83NT6Gzx82eykanQzFhwBK+CXnhWL/vc0XeCADeP2YXbs3gWcI3Ia9vs5Bwqt/3SR0aR2HGUN4/Zv34ZvAs4ZuQ19d/H271+z5z81MoPn6aXrc6HYoJcZbwTUjrq9+HYzmnz7z8FFo6e9hf3ex0KCbEBTzhi0iUiOwQkZcCvbYJPyVhND/nQq7I826IYu2ZZpCcOMP/CrDfgXVNGNriTYJ9u0SFo5zhCYwckcBW2wHLDFJAE76IjARuAn4byHVN+Npc2kBhGM3PuZC5+Z6NzVWtjm8uX6DP8H8GfAO44F0kInK3iBSLSHFdXV3gIjMhp2/+fSjvbtVf8/JTaGjr4mhdm9OhmBAWsIQvIiuBWlXddrHHqeqDqlqkqkXp6ekBis6EopKq5rCv3/eZ672pzOr4ZjACeYa/CFglIseBJ4HlIvJYANc3YeaD+TlheIftufJSh5CeFGf9+BfR3evm+Z2V3Pnbzfzr8yW2PeR5RAdqIVX9J+CfAERkKfB1Vb0rUOub8LPFu39tuNfvAUSEuXkpdoZ/Hk1nuvnj+yd4ZNNxqps6yB2ewKajDby29yT/fstUrpmc6XSIQcP68E1I6ul1s/X46Ygo5/SZm59CVVMHFafPOB1K0PjtulLm/+db/NeaA+SnJfLQp4pY941lPHPvIoYlxPC5R4r58hM7aGjtdDrUoBCwM/yzqeo7wDtOrG3Cw96qZlo7eyIu4YOnjj9yxBCHo3HeltIGfvjKfpaMS+eb109kck7yB5+bOWo4L963mAfePcrP1x5m3eE6Hvr0FcwePcLBiJ1nZ/gmJIXj/PtLmZCZRHJ8tJV1gJaObr72512MThnCL++c/VfJvk9stIsvXz2OV758JUNio/nmX3bT3RvZY6YHnPBFJFFEovwRjDH9tdlbv89Iinc6lIBxueSDfvxI9+8v7aeqsZ2ffGQGiXEXL1SMy0zi+6uncLi2ld9vOBagCIPTJRO+iLhE5OMi8rKI1AIHgGoR2SciPxaRQv+Hacz/09Prpvj4aeZFUDmnzxV5KZTWt1Hb0uF0KI55c99J/lRczj1XFVCU179XeFdPyuSaSRn87M3DVDe1+znC4NWfM/y3gQI8HTZZqjpKVTOAxcBm4L9ExLptTMDsrWqmJcLq9336nvPm0sg8y29o7eRbz+xmYlYSX71m3IC+9l9vnkKvW/nhy5E72aU/Cf8aVf2Bqu5W1Q8KYKp6SlWfVtVbgT/5L0Rj/tqGo/UALIjAhD8lJ5mk+Gg2eb8HkURV+fazJTS39/DTj80kLnpgleVRKUO4d2khL+2uZsORyPv+Qf+6dL4E/PRiD1BVu8PBhw7UNLPuUD1xMS7iol3ERUcRH+Ni9ugRZCRHTs36QjYeaWBiVlJE9N+fKzrKxbz8FDYdjbwbsF7YVcWavTV864aJTMr+24u0/XHPVWN5ensF//J8Ca9+ZQmx0ZHVtzKghC8it6vqk32fEJFMYDbwpiV933hr/0m++MftdHT/bTdB2tBY/vDZuUzJGeZAZMGho7uXrcdPcee8MU6H4pgFBWm8ub+WysZ2cocnOB1OQLjdyv1vHmZKTjKfv3LsZR8nPiaK762azGcfLuZ3G47xhasKfBhl8OvPr7fRIpLkfftX53zuEeBjwOM+jSpCPbW1nLsf3cb4zCTWf3MZ275zDRu/tZy3v76UP909n9goF7c/uJniCB6Tu73sNJ09bhYVRl45p8/CAs9zj6Sz/LUHaimtb+PuJWOJcsmgjrV8YiYrJmfyv28d5mRzZF387k/CPwX8h4isBqJFZMlZn8tW1U8Df/BHcJFCVfn5W4f5xtO7WVSYxhOfn8/IEUNIHRpHzvAE8tMSmTc2lT//n4WkD43jroe28M7BWqfDdsSGo/VEedsTI9WEzCRGDImJqIT/m3Wl5AyL58Zp2T453ndumkR7dy+Pby7zyfFCRX8S/keAdcDngduAn4vIJ0XkG0AtgKq+7L8Qw1uvW/nu8yX85I1DfHhWLg99quiCfcW5wxN46gsLGJs2lM8/UszLu6sDHK3zNhxpYOao4STFxzgdimNcLmFBQSqbjtZHxHz8PRVNbDl2is8syicmyjc19zGpiSwdn86TW8sj6masS373VPU9VX1KVVeq6mvAR4GZQB6eXwJmEH725iEe23yCL1xVwE8+OuOS/6HThsbxxN3zmTlqOPc9sZ1X90RO0m/u6GZ3RSOLCiK3nNNnQUEaVU0dlDWE/1yd36wrZWhcNB+bO8qnx/34vDHUtnTy1v7IebXcnxuv/qpgpqoHVfUfVPVeVT12vseY/ik/dYZfv1fKLTNz+NYNE+nvt3FYQgyPfHYeU3OH8d3n90bMGNjNRxtwKywsTHM6FMf1taRuKg3vsk5lYzsv76nm9itGkezjV3XLJqSTlRzPH98/4dPjBrN+3XglIveJyOizPygisSKyXET+AHzKP+GFtx+tOYBL4Js3TBzw1ybERvHvt0yloa2T/33zsB+iCz4bjzYQH+Ni1ujhTofiOM9YiTg2hnkd/2HvKITPLM73+bGjo1zcPncU6w7XcSICXilB/xL+9UAv8ISIVHlHKhwDDgN3AD9T1Yf9GGNY2nr8FC/vruYLVxWQPezyWuumjxzOx4pG8fDG4xypbfFxhMFnw5F6rshLGfANN+FIpK+O3xC2dfyWjm6efL+cG6dl+6399GNXjEKAJ7ZGxll+f2r4Har6S1VdBIwBrgZmqeoYVf28qu7we5Rhxu1Wvv/iPrKHxXPPksH1AX/9ugkkxEbxvRf2he0PPkBtcweHa1tZbOWcDywsSKW+tZMjta1Oh+IXf9paTktnD5/zw9l9n+xhCSyfmMmfi8vp6gn/i7cDuuStqt2qWq2qjQAiYq+tL8MzOyrZU9nEN6+fSELs4M5W04bG8Q8rxrP+SD2v7a3xUYTBp2+cwiJL+B9YWOD5XoRjWaen183vNxxnbl4KM0b5N83cOX809a1dvL4vfH9++vQr4XtHIs8Vkc+KyE9E5DURqQSO+ze88NPW2cN/rznAjFHDWTUjxyfH/MT8MUzITOIHL+2nvavXJ8cMNhuONDB8SAyTL/OW+nA0KmXIB9v5hZvX9p6ksrGdz13pv7P7PkvGpZM7PIE/bgn/sk5/unSOA4eAHwKzgKPANDxlHTvDH6AH3j1KbUsn/7JyMq5B3jHYJzrKxfdWTaGysZ0H3j3qk2MGE1Vl45F6FoxN9dn3LFwsLEhlU2kDbnd4lfP+VFxOzrB4rp7k//1oo1zCHXNHsfFoA6V14Vke69OfM/wX8dxt+xtVvU9Vfwl0qmrkNK/6SFVjOw++V8qqGTnMGePbrdYWFKRy0/RsHnj3KOWnwqvj4HjDGaqaOqwd8zwWFKTS1N7Nvupmp0PxmZqmDtYfruPWOSMHPUahvz5aNIpol/BEmLdo9uei7X3ASuBGEdkqIjcA4XU6ESCPbCqjx6184/oJfjn+t2+chKrnRpVw0jfK1i7Y/q0FBX3z8cOnrPPMjgrcCrfOHhmwNTOS41kxOZO/bKugsyc8y6LQzxq+qpZ5Z+Z8Gs/dtVkissyPcYWdzp5eniou55pJGX7bgDpneAKrZ+bwVHE5p9u6/LKGEzYcqSdnWDx5qbZx97myhyUwNi0xbC7cqip/2VbBFXkjyEtLDOjaHy0axekz3aw7FL6z8vt70fYHIjJGVfeq6oeBZcC3ReTd/i4kIvEi8r6I7BKRvSLyb5cbdChaU1LDqbYuv4/1/fySsXR0u3ksTIZC9bqVTaUNLCxM6/edyJFmQUEqW0obwqKtcEd5I6V1bdw2J3Bn930WFaaRHB/NK2E8rqS/bZlfAV73dufcBmxT1WuA7w9grU5guarOwDOL53oRmT+wcEPX45tPMCZ1iN/LEuMzk7hqfDp/2FRGR3fovzTdVdFI45lurhxn5ZwLWTI+nbauXorLQn9s9l+2VZAQE8VN033TwTYQsdEurp2SxRv7ToZtWae/Cf+kqk4AfgSsBo6IyI+Biv4upB59l8BjvH8i4lrAwZoW3j9+ijvnjQ5Il8ndS8ZS39rJ8zsr/b6Wv63dX0uUS7hqfLrToQStxYVpxEQJ7xysczqUQeno7uXFXVXcMDWLoReYGOtvN03LpqWzh/WHw7Os09+ErwCq+raqfgKYDpwBSkRkcn8XE5EoEdmJZ6zyG6q65TyPuVtEikWkuK4utP8D9/njljJio13cNse30/4uZGFBKpOzk/nNumMh36639kAtc0aPYPiQWKdDCVqJcdHMy09l7YHQbpx7fd9JWjp6HCnn9Okr67wcpmWdAd1pKyIuEVkFPIpnp6vvAsf6+/Wq2quqM4GRwFwRmXqexzyoqkWqWpSeHvpndW2dPTyzvZKbpmWTkhiYpCUifH5JPkdqW3n3UOj+0qxuamdfdTPLJmY4HUrQWzohnSO1rSHdkvuXbRXkDk9gvoOb08dGu1gxOXzLOv1N+ENF5EdAKXA7cL+qTlTVH6lq+0AX9Y5meBvPYLaw9sKuKlo6e7hr/uhLP9iHVk7PISs5PqRbNN8+4PlldfUkS/iXstz7SzFUd0Krbmpn3eE6bp2d6/jNdTdNz6Klo+eDduBw0t+EfwqoBmar6sdVde1AFxKR9L7ZOyKSAKwADgz0OKFEVXlscxkTs5KYPdq3N1pdSkyUi88symPj0QZKKpsCuravrD1QS+7wBMZlDHU6lKCXn5bImNQhIVvWeWZ7Japwq4PlnD6LC9NJio/m5d3hN1unv334U1X1flUdTBtANp7Z+ruBrXhq+C8N4nhBb1dFE3urmrlz/hhHWgrvmDeaoXHR/DYEz/I7unvZcKSe5RMzrB2zH0SEZRMy2Hi0IeS6s1SVp7dVMDc/hTGpge29Px9PWSeTN/bVhEWr69l8s0FkP6jqblWdparTvb9ABtLSGZIe21xGYmwUH5qV68j6yfEx3H7FKF7cXU1104Arb47aXNpAe3cvy62c02/LJmbQ2eMOuWFq2080Ulrfxm0BvLP2UlZOz6Y5DMs6AUv4kaapvZsXd1Vxy6xcx1rMAD61MA+3Kk+E2CTAtw/UEh/j+mArP3Np8/JTSIiJ4u0Qq+M/s72C+BgXN07PdjqUD3xQ1gmzbh1L+H7yWkkNnT1uPloUmFbMCxmVMoRlEzJ4Yms53b2h8fJUVXnrQC2LCtKIj7HdrforPiaKRYWe9sxQ2Qyns8fTe3/9FOd678+nr6zz+t7wKutYwveTF3dXMSZ1CNNHDnM6FO6aP5q6lk5e33vS6VD65UhtKxWn260d8zIsnZBBxel2jobImN+1+2tp7ujhw0FUzulz0zRvWedo+JR1LOH7QX1rJxuPNnDz9JyguOB41fgMRo5ICJn5On2dJsst4Q9Y3y/JvpbWYPf09koyk+OCciezxePSSIqL5pXd4VPWsYTvB6+W1NDrVm720Y5WgxXlEj4+bzSbShtCYrPztw7UMjEriRw/bVwdznKHJzAhMykk2jMbWjt552Att8zKDdjc+4GIi47ylHX2nQyZcuilWML3gxd3VTEuYygTspKcDuUDHy0aRWyUi8c2B/fF26Yz3WwrO21n94OwdGI6W4+foqWj2+lQLurFXVX0uJUPzwq+ck6fa6dk0dTezdbjoT+YDizh+1x1Uztbj58KmrP7PmlD47hhWhZPb6vgTFeP0+Fc0HuH6+h1q91dOwjLJ2TQ49agbyl8enslU3OTg+rE6FxLxqcRF+3ijX2hcf3rUizh+9jLu6tR9fTxBpu75o+hpbOHF3ZWOR3KBa09UMuIITHMHBXYO5PDyewxI0iKjw7qss6hky3sqWwK6rN7gCGx0SwuTOONfSdDpvPpYizh+9iLu6uZmpvM2PTgGwdQNGYEE7OSeHRzWVD+5+3s6WXtgVqWTsgIyppuqIiJcrF0QgZv7q8N2trzM9sriXYJq2YG1yvh81kxOZOK0+0cqAn+61+XYgnfh040nGFXeSM3O7B5Q3+ICHfOH8PeqmZ2ljc6Hc7fePdgHU3t3awKsnJYKFo1I4dTbV1BOde91608t6OSpRPSSRsa53Q4l3T1pExECIuyjiV8H3ppj6dUclMQlnP6fGhWLomxUTwahC2az++sIiUxlsW2u9WgXTU+nWEJMTwXhJvgbDraQE1zR1D23p9PelIcs0YNt4Rv/tqLu6qZPXq43zYp94WhcdF8aHYuL+2upqG10+lwPtDS0c2b+0+ycno2MVH233KwYqNd3Dgtm9f3nqStM7gu0j+zvYLk+OiQ6sRaMTmLPZVNVDWG1kyqc9lPlo8cqW1hf3Vz0HXnnM+nFuTR1ePmya3lTofygTXeURSrZzozaC4c3TIzh/buXt7cHzxnpi0d3bxaUsPKGTkhNTZjxeRMgKD6Xl4OS/g+8uKuakQ8t2MHu3GZSSwuTOPRTWVBc1Hv+Z1VjE4ZwuzRw50OJWxckZdCzrB4ntsRPGWd53ZU0t7dy8ccnjE1UIUZQxmblhjyZR1L+D6gqry4u4r5+alkJMc7HU6/fGZRHjXNHbxa4vwmD7XNHWw8Ws/qmcExiiJcuFzCzTNzeO9wfVCU7zwbAp1gWu4wZowKvV/sKyZnsrm0geYgv6HtYizh+8Dh2lZK69qCarzrpSybkEFe6hAe3tDvLYn95oVdVbgVK+f4wS0zc+l1a1CM+d16/DQHT7bwifljnA7lsqyYnEl3r/LOwdCYU3Q+lvB9YE1JDSJwnbfOFwpcLuFTC/PYfqKRXQ63aD6/s4qpuckU2laGPjcpO5kJmUk8HwQ32z22uYzk+OiQuM51PrNGjyA1MTakyzqW8H1gTUkNc0aPCJlyTp/b5oxkaFw0v3fwLP9oXSt7Kpu4xc7u/WbVzBy2lZ2m/NQZx2Koa+nk1ZJqbpszioTY0LlYe7Yol3D1pAzeOVAbsjPyLeEP0omGM+yrbua6KVlOhzJgSfEx3DZnJC/vqaa2ucORGJX2p+MAABaWSURBVJ7fUYkIIXvWFwpWe+9mfd7Bnvynisvp7lXunD/asRh8YcXkLFo6e9hcGlrbSPaxhD9Ir+31XPQMxYQP8OmFefS4lccc2AJRVXl+VxULC1LJDLFXR6Fk5IghXJE3gud2VjkyUqPXrfxxywkWFaZSEIQjRwZicWEa8TGhO0wtYAlfREaJyNsisk9E9orIVwK1tj+t2VvD5OxkRqcG781WF5OXlsiyCRn8cUsZnT29AV17Z3kjZQ1n7GJtAKyemcuR2lb2VTcHfO13DtZS2djOXfNC82Lt2RJio1gyLp039p3E7Q6+eVSXEsgz/B7ga6o6GZgPfFFEJgdwfZ+rbe5gW9lprp8ammf3fT6zKI/61i5e2hXYTo5nd1QSG+0K+e9fKLhxWjbRLuGZ7YEv6zy6uYzM5DiuCaGmhou5dkoWNc0d7KlscjqUAQtYwlfValXd7n27BdgPhPSp3evel3WhnrAWF6ZRmDGU364/FrCzllNtXfy5uIKV07NJjo8JyJqRLCUxlhumZfOnreU0nQlcH/mJhjO8e6iO268YHTYjM66Z5Jnm2lfODSWO/AuISB4wC9hyns/dLSLFIlJcVxfc/a6v7a1hbFoi40K8nVBEuHdpAfurm3mlJDBn+Q9vOEZHTy/3Li0IyHoG7l1aQGtnD49sOh6wNR9/vwyXCHfMDe2LtWcbPiSWefkplvD7Q0SGAk8DX1XVvykoquqDqlqkqkXp6emBDq/fGs90seloA9dOyQqLu0NXz8xlfOZQ/uf1Q/T4edxCS0c3D288zvVTsijMCN7djsLNpOxklk/M4HcbjgVk17Pmjm6efL+cFZMyyRoWXhflr5uSxdG6No7UtjodyoAENOGLSAyeZP+4qj4TyLV97a39tfS4NeTLOX2iXMLXrp1AaX0bT2+v8Otaj20+QXNHD/cuLfTrOuZvfXFZAafPdPPE+/4fnPfrd4/S1N7Nl5aH379z3zC11/eF1ll+ILt0BHgI2K+q/xOodf1lzd4asofFMz13mNOh+My1kzOZMWo4P3vzMB3d/unY6eju5aH1pSwZn860keHzvQsVc8akMC8/hd+8V+rXrqza5g4eWn+MVTNymBpGPyN9coYnMH3kMF7bG1rtmYE8w18EfAJYLiI7vX9uDOD6PtPW2cN7h+q4bkoWrjDaik9E+MZ1E6hu6uAxP22Q8lRxOfWtXXzRaveO+eKyQmqaO/w6RfP+tw7T06t87drxflvDaddNyWJXeSM1Tc7ctHg5Atmls15VRVWnq+pM759XArW+L717qI7OHnfI3mx1MYsK01hUmMov3zlKq483zujudfPrd0spGjOCufkpPj226b8rx6UxNTeZX71zlF4/dGUdq2/jya3lfHzeaMakJvr8+MHiuimhV9YJjz6pAFtTUkNKYixX5I1wOhS/+MfrJnKqrYuH1vl2xs5zOyqpbGzni8sKw+JCd6gSEb64tJDjDWd4xQ9TNH/y+kHiol3ct3ycz48dTAozkhibnsjrIVTWsYQ/QJ09vaw9UMs1kzKIDpO+4nPNHDWc66Zk8pt1pZxq6/LJMXvdyq/ePcqk7GSWTgje7qtIcd2ULArSE/nF20d8Om5hT0UTL+2u5u8W55OeFPwblA/WdVOy2FzaENB7GwYjPDOWH60/XE9rZw83hMDOVoPxtWsn0NbVw8/ePOST4720u4rSuja+uKzAzu6DgMsl/J+lhRyoafHphcf/fu0AI4bEcPeSsT47ZjC7bkoWPW7lrQOhcZZvCX+AXi2pISk+mkUFaU6H4lfjM5P41II8HtlUxgu7BjdLvayhje8+V8LU3GRumBrevyhDyeqZOYzPHMo/P7vHJxceNxypZ93her64rJCkCLl7enruMDKT40LmJixL+APQ3evmjX0nuWZSJrHR4f+t++cbJ3FF3gi+8Zdd7Ku6vKFb7V293PPoNkSEX905h6gw6moKdTFRLn5552w6unv50h+3D2p/49NtXXznuRJyhydwV4juaHU5XC7h2slZvHuojvauwA4fvBzhn7V8aNPRBprau8PmZqtLiY128Ys7ZzMsIYZ7Hium8czA6vmqyj8/u4eDJ1v42e0zGZUSmhNFw1lhRhL/+eFpFJed5v977eBlHaOju5fPP1JMZWM7998+k/iY0Nzg5HJdNyWLjm436w4H9ygYsIQ/IK+W1DAkNoqrxkfORceMpHh+ddccTjZ1ct8TOwbUxvfY5jKe3VHJV68ez7IJGX6M0gzG6pm53DV/NL9+r3TAc97dbuVrf95FcdlpfvrRmRTlRV677byxKQxLiOHVkuAv61jC76det/LGvhqWTcyIuDOY2aNH8P3VU1h3uJ4f9/MscFvZab7/0j6WT8zgvjC8tT7cfOemyUzNTeZrT+0c0FaI//XaAV7eXc0/3TCRm6ZH5vWZmCgXN0zN4vW9NUFf1rGE309bj5+ivrWLGyKknHOu2+eO5uPzRvPAu0f57zUHaGjtPO/jVJVtZae49/FtZA9L4KcfnRlWdyOHq/iYKH758TkocO/j22lqv3Sb4aOby/j1u6XcNX90xHTlXMiqmTm0dfUGfbeOJfx+enVPNXHRroguTXzv5incPCOHX75zlIU/Wsu3n93D8fo2AFo7e3hscxk33L+OW3+1iY5uNw/cNYdhQyKjWyMcjE4dwk8+MoOSqiYW/2gt//P6wfNet6k4fYb/u/Yw//p8CcsnZvC9m6dEfKvtvPxUMpPjeG7H4Dra/E2c2OOyv4qKirS4uNjpMHC7lQU/eosZI4fz4CeLnA7HcUdqW/ntulKe2V5Jt9vN/PxUdlc00tbVy+TsZO6aP4bVM3NIjIt2OlRzGfZWNfHzt46wZm8NQ+Oi+dTCMayemcu6w/W8tLuKHScaAc+IhgfummP/zl4/fHkfD288ztZvX8PwIbGOxSEi21T1vInKEn4/bCs7za2/2shPPzaDD80a6XQ4QaO2pYM/bDzOi7uqKcobwV3zxzBr1PCIP9sLFwdqmvn52iO8sqeavjQxOTuZlTOyWTktJ2T3cfaXksomVv58Pf/54WmObvhysYRvv5r7YU1JNTFRwvKJ4bEnp69kJMXzj9dN5B+vm+h0KMYPJmYl84uPz+bQyRY2lzawuDCNsemhvbubP03JSWZseiLP76wM2h2+LOFfgqryyp4aFhWmMSzB6tEm8ozPTGJ8pu1MdikiwuoZufzsrUNUN7WTPSzB6ZD+hl20vYSSymYqG9u50UYCGGMuYdXMHFThpV2B2Rt6oCzhX8KrJdVEueSDLc2MMeZC8tMSmTFyGM/v8t/mMoNhCf8i3G7lhV1VLCxIZUSic1fdjTGhY9XMXEoqm4Nyg3NL+Bex7cRpKk6386FZuU6HYowJETdPz0YEXtgZfGf5lvAv4tkdlSTERIXlVobGGP/ISI5nYUEqz++q8unmMr5gCf8CunrcvLy7mmunZNqNJcaYAVk9I5eyhjPsLG90OpS/ErCELyK/E5FaESkJ1JqD8c7BWprau7nFyjnGmAG6floW8TEunny/3OlQ/kogz/AfBq4P4HqD8tzOSlITY7myMLx3tjLG+F5yfAwfmjWS53ZW+mxfaF8IWMJX1feAU4FabzCa2rt5c38tN8/ICduNyo0x/vWZRXl09rh54v0TTofyActm57GmpJquHrd15xhjLtv4zCQWF6bx6KayQW0f6UtBl/BF5G4RKRaR4ro6Z7YMe3ZHJWPTEpk+cpgj6xtjwsOnF+ZR09zBmiDZDSvoEr6qPqiqRapalJ4e+K0EKxvb2Vx6iltm5drUR2PMoCyfmMGY1CE8vPG406EAQZjwnfbCTs8GBrfMtHKOMWZwXC7hkwvy2FZ2mt0VzrdoBrIt8wlgEzBBRCpE5O8CtXZ/qSrP7qhgzpgRNuvbGOMTHykaSWJsFL/fcNzpUALapXOHqmaraoyqjlTVhwK1dn/tr27h0MlW6703xvhMcnwMHykaxUu7q6ht6XA0FivpnOVPW08QEyXcNM1GIRtjfOeTC8bQ3as8vtnZFk1L+F5N7d38eVsFN8/IIcUmYxpjfGhs+lCWTUjn8S1ldPb0OhaHJXyvPxeXc6arl88uync6FGNMGPrs4nzqW7t4dFOZYzFYwgd63crDG48zNy+FqbnWe2+M8b3FhWksm5DOT984RE2TM7V8S/jAG/tOUnG6nc8uznM6FGNMmBIRvrdqCt1u5Qcv73MkBkv4wO82HGPkiARWTLa598YY/xmTmsi9Swt4eXc16w/XB3z9iE/4JZVNvH/sFJ9akEeUy+6sNcb41xeuKmBM6hD+5fmSgF/AjfiE/7sNxxgSG8VHrxjldCjGmAgQHxPFv62aQml9G795rzSga0d0wq9t6eClXdV8ZM5IhiXEOB2OMSZCLJ2QwQ1Ts/j52iOUnzoTsHUjOuE/vvkEXb1uPrUwz+lQjDER5rsrJxPlEr73wt6A7X0bsQm/o7uXx7eUsXxiBmPThzodjjEmwuQMT+DvrxnPWwdq+dbTe+gJwMz8iN2d+/EtJ6hv7bIbrYwxjvnclfk0d3Tz87VHaGjr5Od3zCYhNspv60XkGf7J5g5++sYhrhqfzqLCVKfDMcZEKBHha9dO4Aerp/DWgVruemgLjWf8twduRCb8H768n65eN/+2aoptcmKMcdwnFuTxi4/PZk9FEx95YBNVje1+WSfiEv7GI/W8sKuKL1xVQF5aotPhGGMMADdOy+YPn51LTVMHt/1qI22dPT5fI6Jq+F09br77fAmjUhK4d2mB0+EYY8xfWVCQyp/uWcCO8tMkxvk+PUdUwn9o/TGO1rXxu08XER/jvwsjxhhzuSbnJDM5J9kvx46Ykk5lYzv/+9Zhrp2cyfKJmU6HY4wxARcxCf8HL+5DUf7l5slOh2KMMY4I+4Svqvzo1QOs2VvDfcvHMXKEbU5ujIlMYV3D73Ur3352D09uLefOeaP5wlV2odYYE7kCeoYvIteLyEEROSIi3/LnWp09vXzpj9t5cms59y0v5N9vmWrjj40xES1gZ/giEgX8AlgBVABbReQFVfX51i+tnT3c82gxG4408N2Vk/m7xTY+wRhjAlnSmQscUdVSABF5ElgN+DThN7V388mHtlBS1cxPPjKDW+eM9OXhjTEmZAUy4ecC5We9XwHMO/dBInI3cDfA6NGjB7xIYmwUeWmJ3Ld8HNdMtvZLY4zpE3QXbVX1QeBBgKKiogEPiY6OcnH/7bN8HpcxxoS6QF60rQTO3kdwpPdjxhhjAiCQCX8rME5E8kUkFrgdeCGA6xtjTEQLWElHVXtE5EvAa0AU8DtV3Ruo9Y0xJtIFtIavqq8ArwRyTWOMMR5hP1rBGGOMhyV8Y4yJEJbwjTEmQljCN8aYCCGqA763KWBEpA4o89Hh0oB6Hx3LSeHwPOw5BAd7DsHDl89jjKqmn+8TQZ3wfUlEilW1yOk4Biscnoc9h+BgzyF4BOp5WEnHGGMihCV8Y4yJEJGU8B90OgAfCYfnYc8hONhzCB4BeR4RU8M3xphIF0ln+MYYE9Es4RtjTISIqIQvIj8Qkd0islNEXheRHKdjGigR+bGIHPA+j2dFZLjTMQ2UiHxERPaKiFtEQqqlTkSuF5GDInJERL7ldDyXQ0R+JyK1IlLidCyXS0RGicjbIrLP+3/pK07HNFAiEi8i74vILu9z+De/rxlJNXwRSVbVZu/bXwYmq+oXHA5rQETkWmCtd9z0fwGo6jcdDmtARGQS4AZ+DXxdVYsdDqlfRCQKOASswLNF51bgDlX16b7M/iYiS4BW4BFVnep0PJdDRLKBbFXdLiJJwDbgllD6txARARJVtVVEYoD1wFdUdbO/1oyoM/y+ZO+VCITcbztVfV1Ve7zvbsazc1hIUdX9qnrQ6Tguw1zgiKqWqmoX8CSw2uGYBkxV3wNOOR3HYKhqtapu977dAuzHs292yFCPVu+7Md4/fs1JEZXwAUTkhyJSDtwJ/IvT8QzSZ4FXnQ4iguQC5We9X0GIJZlwJCJ5wCxgi7ORDJyIRInITqAWeENV/focwi7hi8ibIlJynj+rAVT126o6Cngc+JKz0Z7fpZ6D9zHfBnrwPI+g05/nYMxgichQ4Gngq+e8gg8JqtqrqjPxvFKfKyJ+LbEFdMerQFDVa/r50Mfx7L71r34M57Jc6jmIyKeBlcDVGqQXYQbw7xBKKoFRZ70/0vsx4wBv3ftp4HFVfcbpeAZDVRtF5G3gesBvF9PD7gz/YkRk3FnvrgYOOBXL5RKR64FvAKtU9YzT8USYrcA4EckXkVjgduAFh2OKSN4Lng8B+1X1f5yO53KISHpfl52IJOBpBvBrToq0Lp2ngQl4OkTKgC+oakidoYnIESAOaPB+aHMIdhp9CPg5kA40AjtV9Tpno+ofEbkR+BkQBfxOVX/ocEgDJiJPAEvxjOQ9Cfyrqj7kaFADJCKLgXXAHjw/zwD/7N03OySIyHTgD3j+L7mAp1T1+35dM5ISvjHGRLKIKukYY0wks4RvjDERwhK+McZECEv4xhgTISzhG2NMhLCEb4wxEcISvjHGRAhL+CaoiEivd7+Cvd454V8TEZf3cxu9f+cNZpa7iHxPRL5+GV/XepHP3SIiKiITLzeu/qzTj6+9yjvrvldEjonI1wYbjwkflvBNsGlX1ZmqOgXPreY34J13pKoL/bmweFzuz8QdeOaZ3+HDkC5HFvBnIFVV81X1Jw7HY4KIJXwTtFS1Frgb+JI3GZ995hslIr/xvhJ43TuLBBG5y7uL0E4R+bV30xJE5NsickhE1uMZr4H343neHawewTO0apSIPCci27zHvvtScXonNi4G/g7PfJ2zj73/AnF+17vuehF54nyvOC70XC7hk8CbQFM/HmsijCV8E9RUtRTPrJGMcz41DviF95VAI3CrdyetjwGLvCNne4E7RWQOnkQ8E7gRuOI8x/qlqk5R1TLgs6o6BygCviwiqZcIczWwRlUPAQ3e9S4W5xXArcAMPK9g/mabxws9l0vEAZ4ZRY8CjSLy8X483kSQsBuPbCLGMVXd6X17G5AHDAfmAFs9wxRJwLOxRArwbN90URE5d8Jl2Tnbyn3ZO+ANPOOQx/H/htWdzx3A/d63n/S+v+0icaYBz6tqB9AhIi+e55hXX+C5XJD3+sF/AzcD7wTr6GzjHEv4JqiJyFg8Z7fnJrvOs97uxZMQBfiDqv7TOcf46iWWaTvrsUuBa4AFqnpGRN4B4i8SXwqwHJgmIorn1YiKyD9eJM7+OO9zuYR7gP9R1bcH8DUmglhJxwQtEUkHHgD+bz/PVt8CbhORDO/Xp4jIGOA94BYRSRDPhtc3X+QYw4DT3mQ/EZh/iTVvAx5V1TGqmufdTe0YcOVFvmYDcLOIxHvr/ysH8FwQkbdE5HxbK8bjuWhrzHlZwjfBJqGvLRPPxcfXgX/rzxeq6j7gO8DrIrIbeAPI9m52/SdgF549gLde5DBrgGgR2Q/8CM9G8RdzB/DsOR97mot066jqVjwbp+z2xrOHcy6yXui5eLuICjn/JuQ/BlaIZyvJN0Qk+xKxmwhj8/CNcYCIDFXVVhEZgucVyN3eX0yX+rqpeC4q/8MlHvcHPBtqvOybiE04sBq+Mc54UEQm4ynD/KE/yR5AVUuASyX7lUAinldIxnzAzvCNMSZCWA3fGGMihCV8Y4yJEJbwjTEmQljCN8aYCGEJ3xhjIoQlfGOMiRCW8I0xJkL8/yQm/PaIT5GRAAAAAElFTkSuQmCC\n"
-          },
-          "metadata": {
-            "needs_background": "light"
-          }
-        }
-      ],
-      "source": [
-        "fig, ax = plt.subplots()\n",
-        "\n",
-        "ax.set_xlabel(r\"Dihedral Angle, $\\xi$\")\n",
-        "ax.set_ylabel(r\"$\\nabla A(\\xi)$\")\n",
-        "\n",
-        "ax.plot(mesh, A)\n",
-        "plt.gca()"
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "name": "Butane-FUNN.ipynb",
-      "provenance": []
-    },
-    "jupytext": {
-      "formats": "ipynb,md",
-      "main_language": "python"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.12"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "T-Qkg9C9n7Cc"
+   },
+   "source": [
+    "\n",
+    "# Setting up the environment\n",
+    "\n",
+    "First, we are setting up our environment. We use an already compiled and packaged installation of HOOMD-blue and the DLExt plugin.\n",
+    "We copy it from Google Drive and install PySAGES for it.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "3eTbKklCnyd_"
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "BASE_URL=\"https://drive.google.com/u/0/uc?id=1hsKkKtdxZTVfHKgqVF6qV2e-4SShmhr7&export=download\"\n",
+    "wget -q --load-cookies /tmp/cookies.txt \"$BASE_URL&confirm=$(wget -q --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate $BASE_URL -O- | sed -rn 's/.*confirm=(\\w+).*/\\1\\n/p')\" -O pysages-env.zip\n",
+    "rm -rf /tmp/cookies.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "KRPmkpd9n_NG",
+    "outputId": "2c72bbc3-0731-4d62-98e1-d48f8254adcb"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: PYSAGES_ENV=/env/pysages\n"
+     ]
+    }
+   ],
+   "source": [
+    "%env PYSAGES_ENV=/env/pysages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "J7OY5K9VoBBh"
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "mkdir -p $PYSAGES_ENV .\n",
+    "unzip -qquo pysages-env.zip -d $PYSAGES_ENV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "LlVSU_-FoD4w"
+   },
+   "outputs": [],
+   "source": [
+    "!update-alternatives --auto libcudnn &> /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "EMAWp8VloIk4"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "ver = sys.version_info\n",
+    "sys.path.append(os.environ[\"PYSAGES_ENV\"] + \"/lib/python\" + str(ver.major) + \".\" + str(ver.minor) + \"/site-packages/\")\n",
+    "\n",
+    "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_strict_conv_algorithm_picker=false\"\n",
+    "os.environ[\"LD_LIBRARY_PATH\"] = \"/usr/lib/x86_64-linux-gnu:\" + os.environ[\"LD_LIBRARY_PATH\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "we_mTkFioS6R"
+   },
+   "source": [
+    "\n",
+    "## PySAGES\n",
+    "\n",
+    "The next step is to install PySAGES.\n",
+    "First, we install the jaxlib version that matches the CUDA installation of this Colab setup. See the JAX documentation [here](https://github.com/google/jax) for more details.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "vK0RZtbroQWe"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "pip install -q --upgrade pip\n",
+    "# Installs the wheel compatible with CUDA 11 and cuDNN 8.0.5.\n",
+    "pip install -q --upgrade \"jax[cuda11_cudnn805]\" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html &> /dev/null"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wAtjM-IroYX8"
+   },
+   "source": [
+    "\n",
+    "Now we can finally install PySAGES. We clone the newest version from [here](https://github.com/SSAGESLabs/PySAGES) and build the remaining pure python dependencies and PySAGES itself.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "B-HB9CzioV5j"
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "rm -rf PySAGES\n",
+    "git clone https://github.com/SSAGESLabs/PySAGES.git &> /dev/null\n",
+    "cd PySAGES\n",
+    "pip install -q . &> /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "ppTzMmyyobHB"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "mkdir: cannot create directory ‘/content/funn’: File exists\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "mkdir /content/funn\n",
+    "cd /content/funn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KBFVcG1FoeMq"
+   },
+   "source": [
+    "\n",
+    "# FUNN-biased simulations\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0W2ukJuuojAl"
+   },
+   "source": [
+    "\n",
+    "FUNN gradually learns the free energy gradient from a discrete estimate based on the same algorithm as the ABF method, but employs a neural network to provide a continuous approximation to it.\n",
+    "\n",
+    "For this Colab, we are using butane as the example molecule.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "BBvC7Spoog82"
+   },
+   "outputs": [],
+   "source": [
+    "import hoomd\n",
+    "import hoomd.md\n",
+    "\n",
+    "import numpy\n",
+    "\n",
+    "\n",
+    "pi = numpy.pi\n",
+    "kT = 0.596161\n",
+    "dt = 0.02045\n",
+    "mode = \"--mode=gpu\"\n",
+    "\n",
+    "\n",
+    "def generate_context(kT = kT, dt = dt, mode = mode):\n",
+    "    \"\"\"\n",
+    "    Generates a simulation context, we pass this function to the attribute\n",
+    "    `run` of our sampling method.\n",
+    "    \"\"\"\n",
+    "    hoomd.context.initialize(mode)\n",
+    "\n",
+    "    ### System Definition\n",
+    "    snapshot = hoomd.data.make_snapshot(\n",
+    "        N = 14,\n",
+    "        box = hoomd.data.boxdim(Lx = 41, Ly = 41, Lz = 41),\n",
+    "        particle_types = ['C', 'H'],\n",
+    "        bond_types = [\"CC\", \"CH\"],\n",
+    "        angle_types = [\"CCC\", \"CCH\", \"HCH\"],\n",
+    "        dihedral_types = [\"CCCC\", \"HCCC\", \"HCCH\"],\n",
+    "        pair_types = [\"CCCC\", \"HCCC\", \"HCCH\"],\n",
+    "        dtype = \"double\"\n",
+    "    )\n",
+    "\n",
+    "    snapshot.particles.typeid[0] = 0\n",
+    "    snapshot.particles.typeid[1:4] = 1\n",
+    "    snapshot.particles.typeid[4] = 0\n",
+    "    snapshot.particles.typeid[5:7] = 1\n",
+    "    snapshot.particles.typeid[7] = 0\n",
+    "    snapshot.particles.typeid[8:10] = 1\n",
+    "    snapshot.particles.typeid[10] = 0\n",
+    "    snapshot.particles.typeid[11:14] = 1\n",
+    "\n",
+    "    positions = numpy.array([\n",
+    "        [-2.990196,  0.097881,  0.000091],\n",
+    "        [-2.634894, -0.911406,  0.001002],\n",
+    "        [-2.632173,  0.601251, -0.873601],\n",
+    "        [-4.060195,  0.099327, -0.000736],\n",
+    "        [-2.476854,  0.823942,  1.257436],\n",
+    "        [-2.832157,  1.833228,  1.256526],\n",
+    "        [-2.834877,  0.320572,  2.131128],\n",
+    "        [-0.936856,  0.821861,  1.258628],\n",
+    "        [-0.578833,  1.325231,  0.384935],\n",
+    "        [-0.581553, -0.187426,  1.259538],\n",
+    "        [-0.423514,  1.547922,  2.515972],\n",
+    "        [-0.781537,  1.044552,  3.389664],\n",
+    "        [ 0.646485,  1.546476,  2.516800],\n",
+    "        [-0.778816,  2.557208,  2.515062]\n",
+    "    ])\n",
+    "\n",
+    "    reference_box_low_coords = numpy.array([-22.206855, -19.677099, -19.241968])\n",
+    "    box_low_coords = numpy.array([\n",
+    "        -snapshot.box.Lx / 2,\n",
+    "        -snapshot.box.Ly / 2,\n",
+    "        -snapshot.box.Lz / 2\n",
+    "    ])\n",
+    "    positions += (box_low_coords - reference_box_low_coords)\n",
+    "\n",
+    "    snapshot.particles.position[:] = positions[:]\n",
+    "\n",
+    "    mC = 12.00\n",
+    "    mH = 1.008\n",
+    "    snapshot.particles.mass[:] = [\n",
+    "        mC, mH, mH, mH,\n",
+    "        mC, mH, mH,\n",
+    "        mC, mH, mH,\n",
+    "        mC, mH, mH, mH\n",
+    "    ]\n",
+    "\n",
+    "    reference_charges = numpy.array([\n",
+    "        -0.180000, 0.060000, 0.060000, 0.060000,\n",
+    "        -0.120000, 0.060000, 0.060000,\n",
+    "        -0.120000, 0.060000, 0.060000,\n",
+    "        -0.180000, 0.060000, 0.060000, 0.060000]\n",
+    "    )\n",
+    "    charge_conversion = 18.22262\n",
+    "    snapshot.particles.charge[:] = charge_conversion * reference_charges[:]\n",
+    "\n",
+    "    snapshot.bonds.resize(13)\n",
+    "    snapshot.bonds.typeid[0:3] = 1\n",
+    "    snapshot.bonds.typeid[3] = 0\n",
+    "    snapshot.bonds.typeid[4:6] = 1\n",
+    "    snapshot.bonds.typeid[6] = 0\n",
+    "    snapshot.bonds.typeid[7:9] = 1\n",
+    "    snapshot.bonds.typeid[9] = 0\n",
+    "    snapshot.bonds.typeid[10:13] = 1\n",
+    "\n",
+    "    snapshot.bonds.group[:] = [\n",
+    "        [0, 2], [0, 1], [0, 3], [0, 4],\n",
+    "        [4, 5], [4, 6], [4, 7],\n",
+    "        [7, 8], [7, 9], [7, 10],\n",
+    "        [10, 11], [10, 12], [10, 13]\n",
+    "    ]\n",
+    "\n",
+    "    snapshot.angles.resize(24)\n",
+    "    snapshot.angles.typeid[0:2] = 2\n",
+    "    snapshot.angles.typeid[2] = 1\n",
+    "    snapshot.angles.typeid[3] = 2\n",
+    "    snapshot.angles.typeid[4:8] = 1\n",
+    "    snapshot.angles.typeid[8] = 0\n",
+    "    snapshot.angles.typeid[9] = 2\n",
+    "    snapshot.angles.typeid[10:14] = 1\n",
+    "    snapshot.angles.typeid[14] = 0\n",
+    "    snapshot.angles.typeid[15] = 2\n",
+    "    snapshot.angles.typeid[16:21] = 1\n",
+    "    snapshot.angles.typeid[21:24] = 2\n",
+    "\n",
+    "    snapshot.angles.group[:] = [\n",
+    "        [1, 0, 2], [2, 0, 3], [2, 0, 4],\n",
+    "        [1, 0, 3], [1, 0, 4], [3, 0, 4],\n",
+    "        [0, 4, 5], [0, 4, 6], [0, 4, 7],\n",
+    "        [5, 4, 6], [5, 4, 7], [6, 4, 7],\n",
+    "        [4, 7, 8], [4, 7, 9], [4, 7, 10],\n",
+    "        [8, 7, 9], [8, 7, 10], [9, 7, 10],\n",
+    "        [7, 10, 11], [7, 10, 12], [7, 10, 13],\n",
+    "        [11, 10, 12], [11, 10, 13], [12, 10, 13]\n",
+    "    ]\n",
+    "\n",
+    "    snapshot.dihedrals.resize(27)\n",
+    "    snapshot.dihedrals.typeid[0:2] = 2\n",
+    "    snapshot.dihedrals.typeid[2] = 1\n",
+    "    snapshot.dihedrals.typeid[3:5] = 2\n",
+    "    snapshot.dihedrals.typeid[5] = 1\n",
+    "    snapshot.dihedrals.typeid[6:8] = 2\n",
+    "    snapshot.dihedrals.typeid[8:11] = 1\n",
+    "    snapshot.dihedrals.typeid[11] = 0\n",
+    "    snapshot.dihedrals.typeid[12:14] = 2\n",
+    "    snapshot.dihedrals.typeid[14] = 1\n",
+    "    snapshot.dihedrals.typeid[15:17] = 2\n",
+    "    snapshot.dihedrals.typeid[17:21] = 1\n",
+    "    snapshot.dihedrals.typeid[21:27] = 2\n",
+    "\n",
+    "    snapshot.dihedrals.group[:] = [\n",
+    "        [2, 0, 4, 5], [2, 0, 4, 6], [2, 0, 4, 7],\n",
+    "        [1, 0, 4, 5], [1, 0, 4, 6], [1, 0, 4, 7],\n",
+    "        [3, 0, 4, 5], [3, 0, 4, 6], [3, 0, 4, 7],\n",
+    "        [0, 4, 7, 8], [0, 4, 7, 9], [0, 4, 7, 10],\n",
+    "        [5, 4, 7, 8], [5, 4, 7, 9], [5, 4, 7, 10],\n",
+    "        [6, 4, 7, 8], [6, 4, 7, 9], [6, 4, 7, 10],\n",
+    "        [4, 7, 10, 11], [4, 7, 10, 12], [4, 7, 10, 13],\n",
+    "        [8, 7, 10, 11], [8, 7, 10, 12], [8, 7, 10, 13],\n",
+    "        [9, 7, 10, 11], [9, 7, 10, 12], [9, 7, 10, 13]\n",
+    "    ]\n",
+    "\n",
+    "    snapshot.pairs.resize(27)\n",
+    "    snapshot.pairs.typeid[0:1] = 0\n",
+    "    snapshot.pairs.typeid[1:11] = 1\n",
+    "    snapshot.pairs.typeid[11:27] = 2\n",
+    "    snapshot.pairs.group[:] = [\n",
+    "        # CCCC\n",
+    "        [0, 10],\n",
+    "        # HCCC\n",
+    "        [0, 8], [0, 9], [5, 10], [6, 10],\n",
+    "        [1, 7], [2, 7], [3, 7],\n",
+    "        [11, 4], [12, 4], [13, 4],\n",
+    "        # HCCH\n",
+    "        [1, 5], [1, 6], [2, 5], [2, 6], [3, 5], [3, 6],\n",
+    "        [5, 8], [6, 8], [5, 9], [6, 9],\n",
+    "        [8, 11], [8, 12], [8, 13], [9, 11], [9, 12], [9, 13]\n",
+    "    ]\n",
+    "\n",
+    "    hoomd.init.read_snapshot(snapshot)\n",
+    "\n",
+    "    ### Set interactions\n",
+    "    nl_ex = hoomd.md.nlist.cell()\n",
+    "    nl_ex.reset_exclusions(exclusions = [\"1-2\", \"1-3\", \"1-4\"])\n",
+    "\n",
+    "    lj = hoomd.md.pair.lj(r_cut = 12.0, nlist = nl_ex)\n",
+    "    lj.pair_coeff.set('C', 'C', epsilon = 0.07, sigma = 3.55)\n",
+    "    lj.pair_coeff.set('H', 'H', epsilon = 0.03, sigma = 2.42)\n",
+    "    lj.pair_coeff.set('C', 'H', epsilon = numpy.sqrt(0.07*0.03), sigma = numpy.sqrt(3.55*2.42))\n",
+    "\n",
+    "    coulomb = hoomd.md.charge.pppm(hoomd.group.charged(), nlist = nl_ex)\n",
+    "    coulomb.set_params(Nx = 64, Ny = 64, Nz = 64, order = 6, rcut = 12.0)\n",
+    "\n",
+    "    harmonic = hoomd.md.bond.harmonic()\n",
+    "    harmonic.bond_coeff.set(\"CC\", k = 2*268.0, r0 = 1.529)\n",
+    "    harmonic.bond_coeff.set(\"CH\", k = 2*340.0, r0 = 1.09)\n",
+    "\n",
+    "    angle = hoomd.md.angle.harmonic()\n",
+    "    angle.angle_coeff.set(\"CCC\", k = 2*58.35, t0 = 112.7 * pi / 180)\n",
+    "    angle.angle_coeff.set(\"CCH\", k = 2*37.5, t0 = 110.7 * pi / 180)\n",
+    "    angle.angle_coeff.set(\"HCH\", k = 2*33.0, t0 = 107.8 * pi / 180)\n",
+    "\n",
+    "\n",
+    "    dihedral = hoomd.md.dihedral.opls()\n",
+    "    dihedral.dihedral_coeff.set(\"CCCC\", k1 = 1.3, k2 = -0.05, k3 = 0.2, k4 = 0.0)\n",
+    "    dihedral.dihedral_coeff.set(\"HCCC\", k1 = 0.0, k2 = 0.0, k3 = 0.3, k4 = 0.0)\n",
+    "    dihedral.dihedral_coeff.set(\"HCCH\", k1 = 0.0, k2 = 0.0, k3 = 0.3, k4 = 0.0)\n",
+    "\n",
+    "    lj_special_pairs = hoomd.md.special_pair.lj()\n",
+    "    lj_special_pairs.pair_coeff.set(\"CCCC\", epsilon = 0.07, sigma = 3.55, r_cut = 12.0)\n",
+    "    lj_special_pairs.pair_coeff.set(\"HCCH\", epsilon = 0.03, sigma = 2.42, r_cut = 12.0)\n",
+    "    lj_special_pairs.pair_coeff.set(\"HCCC\",\n",
+    "        epsilon = numpy.sqrt(0.07 * 0.03), sigma = numpy.sqrt(3.55 * 2.42), r_cut = 12.0\n",
+    "    )\n",
+    "\n",
+    "    coulomb_special_pairs = hoomd.md.special_pair.coulomb()\n",
+    "    coulomb_special_pairs.pair_coeff.set(\"CCCC\", alpha = 0.5, r_cut = 12.0)\n",
+    "    coulomb_special_pairs.pair_coeff.set(\"HCCC\", alpha = 0.5, r_cut = 12.0)\n",
+    "    coulomb_special_pairs.pair_coeff.set(\"HCCH\", alpha = 0.5, r_cut = 12.0)\n",
+    "\n",
+    "    hoomd.md.integrate.mode_standard(dt = dt)\n",
+    "    integrator = hoomd.md.integrate.nvt(group = hoomd.group.all(), kT = kT, tau = 100*dt)\n",
+    "    integrator.randomize_velocities(seed = 42)\n",
+    "\n",
+    "    return hoomd.context.current"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3UrzENm_oo6U"
+   },
+   "source": [
+    "\n",
+    "Next, we load PySAGES and the relevant classes and methods for our problem\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "fpMg-o8WomAA"
+   },
+   "outputs": [],
+   "source": [
+    "from pysages.grids import Grid\n",
+    "from pysages.colvars import DihedralAngle\n",
+    "from pysages.methods import FUNN\n",
+    "\n",
+    "import pysages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LknkRvo1o4av"
+   },
+   "source": [
+    "\n",
+    "The next step is to define the collective variable (CV). In this case, we choose the central dihedral angle.\n",
+    "\n",
+    "We also define a grid to bin our CV space, the topology (tuple indicating the number of\n",
+    "nodes of each hidden layer) for our neural network which will model the free energy.\n",
+    "\n",
+    "The appropriate number of bins depends on the complexity of the free energy landscape,\n",
+    "a good rule of thumb is to choose between 20 to 100 bins along each CV dimension\n",
+    "(using higher values for more rugged free energy surfaces), but it can be systematically\n",
+    "found trying different values for short runs of any given system.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "id": "B1Z8FWz0o7u_"
+   },
+   "outputs": [],
+   "source": [
+    "cvs = [DihedralAngle([0, 4, 7, 10])]\n",
+    "grid = Grid(lower=(-pi,), upper=(pi,), shape=(64,), periodic=True)\n",
+    "\n",
+    "topology = (14,)\n",
+    "method = FUNN(cvs, grid, topology)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Fz8BfU34pA_N"
+   },
+   "source": [
+    "\n",
+    "We now simulate $5\\times10^5$ time steps.\n",
+    "Make sure to run with GPU support, otherwise, it can take a very long time.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "K951m4BbpUar",
+    "outputId": "f3e79872-41da-479a-caec-5bca7a6792e5"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HOOMD-blue v2.9.7 CUDA (11.1) DOUBLE HPMC_MIXED SSE SSE2 \n",
+      "Compiled: 07/07/2022\n",
+      "Copyright (c) 2009-2019 The Regents of the University of Michigan.\n",
+      "-----\n",
+      "You are using HOOMD-blue. Please cite the following:\n",
+      "* J A Anderson, J Glaser, and S C Glotzer. \"HOOMD-blue: A Python package for\n",
+      "  high-performance molecular dynamics and hard particle Monte Carlo\n",
+      "  simulations\", Computational Materials Science 173 (2020) 109363\n",
+      "-----\n",
+      "HOOMD-blue is running on the following GPU(s):\n",
+      " [0]              Tesla T4  40 SM_7.5 @ 1.59 GHz, 15109 MiB DRAM, MNG\n",
+      "notice(2): Group \"all\" created containing 14 particles\n",
+      "notice(2): -- Neighborlist exclusion statistics -- :\n",
+      "notice(2): Particles with 7 exclusions             : 6\n",
+      "notice(2): Particles with 10 exclusions             : 6\n",
+      "notice(2): Particles with 13 exclusions             : 2\n",
+      "notice(2): Neighbors included by diameter          : no\n",
+      "notice(2): Neighbors excluded when in the same body: no\n",
+      "notice(2): Group \"charged\" created containing 14 particles\n",
+      "-----\n",
+      "You are using PPPM. Please cite the following:\n",
+      "* D N LeBard, B G Levine, S A Barr, A Jusufi, S Sanders, M L Klein, and A Z\n",
+      "  Panagiotopoulos. \"Self-assembly of coarse-grained ionic surfactants\n",
+      "  accelerated by graphics processing units\", Journal of Computational Physics 8\n",
+      "  (2012) 2385-2397\n",
+      "-----\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.7/dist-packages/pysages/ml/utils.py:54: FutureWarning: jax.tree_flatten is deprecated, and will be removed in a future release. Use jax.tree_util.tree_flatten instead.\n",
+      "  data, structure = tree_flatten(params)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "** starting run **\n",
+      "notice(2): charge.pppm: RMS error: 1.29239e-08\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+      "  dp = solve(H, Je, sym_pos=True)\n",
+      "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+      "  dp = solve(H, Je, sym_pos=True)\n",
+      "/usr/local/lib/python3.7/dist-packages/pysages/methods/funn.py:191: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+      "  Wp = linalg.solve(Jxi @ Jxi.T, Jxi @ p, sym_pos=\"sym\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time 00:00:15 | Step 2382 / 500000 | TPS 238.192 | ETA 00:34:49\n",
+      "Time 00:00:25 | Step 9800 / 500000 | TPS 741.731 | ETA 00:11:00\n",
+      "Time 00:00:35 | Step 16594 / 500000 | TPS 679.375 | ETA 00:11:51\n",
+      "Time 00:00:45 | Step 23699 / 500000 | TPS 710.482 | ETA 00:11:10\n",
+      "Time 00:00:55 | Step 30685 / 500000 | TPS 698.565 | ETA 00:11:11\n",
+      "Time 00:01:05 | Step 38038 / 500000 | TPS 735.282 | ETA 00:10:28\n",
+      "Time 00:01:15 | Step 44802 / 500000 | TPS 676.339 | ETA 00:11:13\n",
+      "Time 00:01:25 | Step 51935 / 500000 | TPS 713.242 | ETA 00:10:28\n",
+      "Time 00:01:35 | Step 59345 / 500000 | TPS 740.912 | ETA 00:09:54\n",
+      "Time 00:01:45 | Step 66486 / 500000 | TPS 714.031 | ETA 00:10:07\n",
+      "Time 00:01:55 | Step 73877 / 500000 | TPS 739.073 | ETA 00:09:36\n",
+      "Time 00:02:05 | Step 81221 / 500000 | TPS 734.045 | ETA 00:09:30\n",
+      "Time 00:02:15 | Step 88551 / 500000 | TPS 732.972 | ETA 00:09:21\n",
+      "Time 00:02:25 | Step 95662 / 500000 | TPS 711.075 | ETA 00:09:28\n",
+      "Time 00:02:35 | Step 102927 / 500000 | TPS 726.454 | ETA 00:09:06\n",
+      "Time 00:02:45 | Step 110189 / 500000 | TPS 726.175 | ETA 00:08:56\n",
+      "Time 00:02:55 | Step 117219 / 500000 | TPS 702.939 | ETA 00:09:04\n",
+      "Time 00:03:05 | Step 124386 / 500000 | TPS 716.627 | ETA 00:08:44\n",
+      "Time 00:03:15 | Step 131649 / 500000 | TPS 726.238 | ETA 00:08:27\n",
+      "Time 00:03:25 | Step 138980 / 500000 | TPS 733.08 | ETA 00:08:12\n",
+      "Time 00:03:35 | Step 146259 / 500000 | TPS 727.83 | ETA 00:08:06\n",
+      "Time 00:03:45 | Step 153598 / 500000 | TPS 733.834 | ETA 00:07:52\n",
+      "Time 00:03:55 | Step 160870 / 500000 | TPS 727.165 | ETA 00:07:46\n",
+      "Time 00:04:05 | Step 168150 / 500000 | TPS 727.977 | ETA 00:07:35\n",
+      "Time 00:04:15 | Step 175412 / 500000 | TPS 726.142 | ETA 00:07:27\n",
+      "Time 00:04:25 | Step 182753 / 500000 | TPS 734.066 | ETA 00:07:12\n",
+      "Time 00:04:35 | Step 190001 / 500000 | TPS 721.559 | ETA 00:07:09\n",
+      "Time 00:04:45 | Step 197404 / 500000 | TPS 740.255 | ETA 00:06:48\n",
+      "Time 00:04:55 | Step 204713 / 500000 | TPS 730.888 | ETA 00:06:44\n",
+      "Time 00:05:05 | Step 212053 / 500000 | TPS 733.967 | ETA 00:06:32\n",
+      "Time 00:05:15 | Step 219418 / 500000 | TPS 736.472 | ETA 00:06:20\n",
+      "Time 00:05:25 | Step 226762 / 500000 | TPS 734.326 | ETA 00:06:12\n",
+      "Time 00:05:35 | Step 233828 / 500000 | TPS 706.592 | ETA 00:06:16\n",
+      "Time 00:05:45 | Step 240993 / 500000 | TPS 716.425 | ETA 00:06:01\n",
+      "Time 00:05:55 | Step 248322 / 500000 | TPS 732.826 | ETA 00:05:43\n",
+      "Time 00:06:05 | Step 255645 / 500000 | TPS 732.213 | ETA 00:05:33\n",
+      "Time 00:06:15 | Step 263035 / 500000 | TPS 738.913 | ETA 00:05:20\n",
+      "Time 00:06:25 | Step 270349 / 500000 | TPS 731.387 | ETA 00:05:13\n",
+      "Time 00:06:35 | Step 277694 / 500000 | TPS 734.447 | ETA 00:05:02\n",
+      "Time 00:06:45 | Step 285001 / 500000 | TPS 730.286 | ETA 00:04:54\n",
+      "Time 00:06:55 | Step 292333 / 500000 | TPS 733.145 | ETA 00:04:43\n",
+      "Time 00:07:05 | Step 299675 / 500000 | TPS 734.125 | ETA 00:04:32\n",
+      "Time 00:07:15 | Step 307066 / 500000 | TPS 739.064 | ETA 00:04:21\n",
+      "Time 00:07:25 | Step 314514 / 500000 | TPS 744.769 | ETA 00:04:09\n",
+      "Time 00:07:35 | Step 321962 / 500000 | TPS 744.749 | ETA 00:03:59\n",
+      "Time 00:07:45 | Step 329389 / 500000 | TPS 742.647 | ETA 00:03:49\n",
+      "Time 00:07:55 | Step 336764 / 500000 | TPS 737.498 | ETA 00:03:41\n",
+      "Time 00:08:05 | Step 344194 / 500000 | TPS 742.825 | ETA 00:03:29\n",
+      "Time 00:08:15 | Step 351001 / 500000 | TPS 680.669 | ETA 00:03:38\n",
+      "Time 00:08:25 | Step 358207 / 500000 | TPS 720.552 | ETA 00:03:16\n",
+      "Time 00:08:35 | Step 365515 / 500000 | TPS 730.713 | ETA 00:03:04\n",
+      "Time 00:08:45 | Step 372786 / 500000 | TPS 727.084 | ETA 00:02:54\n",
+      "Time 00:08:55 | Step 380039 / 500000 | TPS 725.232 | ETA 00:02:45\n",
+      "Time 00:09:05 | Step 387469 / 500000 | TPS 742.9 | ETA 00:02:31\n",
+      "Time 00:09:15 | Step 394910 / 500000 | TPS 744.028 | ETA 00:02:21\n",
+      "Time 00:09:25 | Step 402050 / 500000 | TPS 713.989 | ETA 00:02:17\n",
+      "Time 00:09:35 | Step 409480 / 500000 | TPS 742.954 | ETA 00:02:01\n",
+      "Time 00:09:45 | Step 416909 / 500000 | TPS 742.893 | ETA 00:01:51\n",
+      "Time 00:09:55 | Step 424338 / 500000 | TPS 742.894 | ETA 00:01:41\n",
+      "Time 00:10:05 | Step 431758 / 500000 | TPS 741.955 | ETA 00:01:31\n",
+      "Time 00:10:15 | Step 439226 / 500000 | TPS 746.72 | ETA 00:01:21\n",
+      "Time 00:10:25 | Step 446648 / 500000 | TPS 742.13 | ETA 00:01:11\n",
+      "Time 00:10:35 | Step 454097 / 500000 | TPS 744.802 | ETA 00:01:01\n",
+      "Time 00:10:45 | Step 461493 / 500000 | TPS 739.54 | ETA 00:00:52\n",
+      "Time 00:10:55 | Step 468989 / 500000 | TPS 749.58 | ETA 00:00:41\n",
+      "Time 00:11:05 | Step 476190 / 500000 | TPS 720.017 | ETA 00:00:33\n",
+      "Time 00:11:15 | Step 483637 / 500000 | TPS 744.693 | ETA 00:00:21\n",
+      "Time 00:11:25 | Step 491091 / 500000 | TPS 745.319 | ETA 00:00:11\n",
+      "Time 00:11:35 | Step 498561 / 500000 | TPS 746.975 | ETA 00:00:01\n",
+      "Time 00:11:37 | Step 500000 / 500000 | TPS 742.668 | ETA 00:00:00\n",
+      "Average TPS: 722.503\n",
+      "---------\n",
+      "-- Neighborlist stats:\n",
+      "82696 normal updates / 1667 forced updates / 0 dangerous updates\n",
+      "n_neigh_min: 0 / n_neigh_max: 6 / n_neigh_avg: 3.85714\n",
+      "shortest rebuild period: 3\n",
+      "-- Cell list stats:\n",
+      "Dimension: 3, 3, 3\n",
+      "n_min    : 0 / n_max: 14 / n_avg: 0.518519\n",
+      "** run complete **\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_result = pysages.run(method, generate_context, int(5e5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PXBKUfK0p9T2"
+   },
+   "source": [
+    "\n",
+    "Let's now plot the free energy landscape learned by the FUNN sampling method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "id": "X69d1R7OpW4P"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "id": "6W7Xf0ilqAcm"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.7/dist-packages/pysages/ml/utils.py:54: FutureWarning: jax.tree_flatten is deprecated, and will be removed in a future release. Use jax.tree_util.tree_flatten instead.\n",
+      "  data, structure = tree_flatten(params)\n",
+      "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+      "  dp = solve(H, Je, sym_pos=True)\n",
+      "/usr/local/lib/python3.7/dist-packages/pysages/ml/optimizers.py:214: FutureWarning: The sym_pos argument to solve() is deprecated and will be removed in a future JAX release. Use assume_a='pos' instead.\n",
+      "  dp = solve(H, Je, sym_pos=True)\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = pysages.analyze(run_result)\n",
+    "\n",
+    "mesh = result[\"mesh\"]\n",
+    "A = result[\"free_energy\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 300
+    },
+    "id": "TBiPAnMwqEIF",
+    "lines_to_next_cell": 0,
+    "outputId": "3a13a52d-2bd8-4122-db13-18bc6a11c797"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7f07042f45d0>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEMCAYAAADHxQ0LAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3xcd5Xw/88ZdcuSbfXiIlly77biHsd24lTHDiRAQkJdSHgCAXZhgV1gl4Vll11+LGR5gBAIhBQSAunNaU5xj+Uud1u2rGoVW9Xqc35/zCiPMS6SNTN3ynm/Xn5ZZXS/Z2Tr6M65556vqCrGGGPCn8vpAIwxxgSGJXxjjIkQlvCNMSZCWMI3xpgIYQnfGGMihCV8Y4yJEAFL+CIyQUR2nvWnWUS+Gqj1jTEm0okTffgiEgVUAvNUtexCj0tLS9O8vLyAxWWMMaFu27Zt9aqafr7PRQc6GK+rgaMXS/YAeXl5FBcXBygkY4wJfSJywbzqVA3/duCJ831CRO4WkWIRKa6rqwtwWMYYE74CnvBFJBZYBfz5fJ9X1QdVtUhVi9LTz/uqxBhjzGVw4gz/BmC7qp50YG1jjIlYTiT8O7hAOccYY4z/BDThi0gisAJ4JpDrGmOMCXCXjqq2AamBXNMYY4yH3WlrjDERwqk+fGNCUmdPL5Wn26k43U756TOowseuGEVMlJ07meBnCd+Yfjh8soV7Ht1GaX3b33xuc2kD998+iyiXOBCZMf1nCd+YS2jp6OaeR7fR3NHN318znpEjEhiVMoSRIxJ4cVcV//nqARJjo/nRrdMQsaRvgpclfGMuQlX5+p93UXbqDI9/bh7zx/51z8E9VxXQ1tnD/649QmJcNN9dOcmSvglalvCNuYgH3i3ltb0n+c5Nk/4m2ff5+xXjaens4XcbjpEUH83frxgf4CiN6R9L+MZcwIYj9fz4tQOsnJ7N3y3Ov+DjRITv3jSZts4e7n/rMEnx0XzuyrEBjNSY/rHWAmPOo7Kxnfue2EFB+lD+69bplyzTuFzCf354OjdMzeI/XtnPiYYzAYrUmP6zhG/MOdxu5d7Ht9PV4+aBT8whMa5/L4SjXML3Vk0hyiX8dn2pn6M0ZuAs4RtzjrUHatlV3sj3Vk2hIH3ogL42MzmeD83K5anichpaO/0UoTGXxxK+Mef4/cZjZCXHs3pmzmV9/d1LxtLR7eaRTRfd38eYgLOEb8xZDta0sOFIA59cOOay754tzEjimkmZPLLpOGe6enwboDGDYAnfmLP8fsMx4mNc3HHF6EEd5wtXjeX0mW6e2lruo8iMGTxL+MZ4nWrr4tkdlXxo1khGJMYO6lhFeSkUjRnBb9Ydo6fX7aMIjRkcS/jGeD3x/gk6e9x8ZlGeT453z1UFVDa28/Keap8cz5jBsoRvDNDd6+aRTce5clwa4zOTfHLMqydmUJCeyK/fLUVVfXJMYwbDEr4xwCt7qjnZ3Omzs3vw3Ix1z5IC9lU3s/5Ivc+Oa8zlsoRvDPD7DcfJT0tk6fgMnx539awcMpLi+M26Yz49rjGXwxK+iXjbT5xmZ3kjn16Yh8vHM+3joqP4SNFINhyp51Rbl0+PbcxAWcI3Ee/3G46TFBfNrXNG+uX4N0zNptetvLGvxi/HN6a/LOGbiNba2cNre2v48OxchvZzZs5ATclJZuSIBNaUWMI3zgpowheR4SLyFxE5ICL7RWRBINc35lzvHKylq8fNjdOy/baGiHDD1CzWH6mnuaPbb+sYcymBPsO/H1ijqhOBGcD+AK9vzF9ZU1JD2tBYivJS/LrO9VOz6e5V1u6v9es6xlxMwBK+iAwDlgAPAahql6o2Bmp9Y87V0d3L2wdqWTE5y+8bkM8aNZzM5DheLbGbsIxzAnmGnw/UAb8XkR0i8lsRSTz3QSJyt4gUi0hxXV1dAMMzkWb94Xraunq5fmqW39dyuYTrpmTx7qE6G6hmHBPIhB8NzAZ+paqzgDbgW+c+SFUfVNUiVS1KT08PYHgm0qzZW0NSfDQLLrBXra9dPzWLjm437x60ExnjjEAm/AqgQlW3eN//C55fAMYEXHevmzf2nWTFpExiowPzYzA3L4WUxFhetW4d45CAJXxVrQHKRWSC90NXA/sCtb4xZ9tSeoqm9m6uC0A5p090lIsVkzJZe6CWzp7egK1rTJ9Ad+ncBzwuIruBmcB/BHh9YwBYs7eahJgolowLbNnw+mlZtHb2sP6wzdYxgeefO00uQFV3AkWBXNOYc7ndymt7T7JsYjoJsVEBXXtRQRpJ8dG8WlLD1ZMyA7q2MXanrYk420+cpq6lk+umBK6c0yc22sU1kzJ5c/9Jum1jFBNglvBNxFlTUkNslIvlE307GbO/rp+aReOZbraUnnJkfRO5LOGbiKKqrNlbw+JxaSTFxzgSw5Jx6STERLFmr92EZQLLEr6JKHurmqk43c71DpRz+iTERrGoMJV1duHWBJglfBNR1pTUEOUSrpns7AXTRYVplDWcofzUGUfjMJHFEr6JKGsP1FI0ZgQpibGOxrG4MA2ADbb1oQkgS/gmYtS1dLKvupkl450f2VGYMZSMpDjb69YElCV8EzE2HvUk1yvHpTkciWdG/uLCNDYebcDtVqfDMRHCEr6JGO8dqmfEkBim5AxzOhQAFo9L41RbF/trmp0OxUQIS/gmIqgq6w7Xsagwze+z7/trkdXxTYBZwjcR4dDJVmpbOoOinNMnMzmecRlDrT3TBIwlfBMR1h32zKBfHOBhaZeyqDCNrcdP0dFt0zON/1nCNxFh3eF6CtITyR2e4HQof2VxYRod3W62nzjtdCgmAljCN2Gvo7uXLccauDLIzu4B5o1NIcolVsc3AWEJ34S97WWn6eh2B1X9vk9SfAyzRg1n/ZEGp0MxEcASvgl77x2uJ9olzAvQ3rUDtagwjT0VjTSd6XY6FBPmLOGbsLfucB2zx4xgaFxA9/vpt8Xj0nArbCq1so7xL0v4Jqw1tHayt6qZJUFYzukzc9RwEmOjbMyC8TtL+Cas9SXRYGvHPFtMlIt5Y1PZYHV842eW8E1YW3e4nmEJMUzLDY5xCheyuDCNY/VtVJy2ccnGfwKa8EXkuIjsEZGdIlIcyLVN5FFV1h+uZ3EQjVO4kMXjbMyC8T8nzvCXqepMVS1yYG0TQY7UtlLT3PFBMg1m4zKGkjY01va5NX5lJR0Ttt7zzqjp22wkmIkIc/NT2HLMEr7xn0AnfAVeF5FtInL3+R4gIneLSLGIFNfV1QU4PBNONh1tYEzqEEalDHE6lH6Zm5dCZWO71fGN3wQ64S9W1dnADcAXRWTJuQ9Q1QdVtUhVi9LTg7ezwgS3Xrey5VgDC4L0ZqvzmZvvifV9O8s3fhLQhK+qld6/a4FngbmBXN9Ejv3VzbR09DA/hBL+xKwkkuOjLeEbvwlYwheRRBFJ6nsbuBYoCdT6JrJsLvX0tIdSwne5rI5v/CuQZ/iZwHoR2QW8D7ysqmsCuL6JIJuONpCflkjWsHinQxmQufkpHKtvo7a5w+lQTBgK2HARVS0FZgRqPRO5et3K+8dOsXJGttOhDNi8vjr+8VOsnJ7jcDQm3Fhbpgk7e6uaaOkMrfp9nyk5ySTGRlk/vvELS/gm7PTV70OpQ6dPdJSLOXkpduHW+IUlfBN2NpeeYmx6IhnJoVW/7zMvP4WDJ1s43dbldCgmzFjCN2Glp9fN+8dOhWQ5p8/c/BTAU8c3xpcs4ZuwsreqmdYQrd/3mT5yGHHRLivrGJ+zhG/CyqYP+u9THI7k8sVFRzFr9HBL+MbnLOGbsLK5tIGC9EQykkKzft9nbn4qe6uaaO6wfW6N71jCN2Gjp9fN1mOnWFAQuuWcPvPzU3ArbCs77XQoJoxYwjdhY09lE21dvSFdv+8za/QIol1iZR3jU5bwTdjY7L1Zqe9u1VCWEBvF9JHD2FJq+9wa37GEb8LG5tIGxmUMJT0pzulQfGLe2FR2VzTR3tXrdCgmTFjCN2Ghu9fN1uOh3X9/rrn5KfS4le0nrI5vfMMSvgkLeyqbOBMm9fs+c8aMwCW2IYrxHUv4Jiz0zc+ZF8L99+dKjo9hck6yJXzjM5bwTVjYXHqK8ZlDSRsaHvX7PnPzUtl+4jRdPW6nQzFhwBK+CXndvW6Kj58Ki+6cc83NT6Gzx82eykanQzFhwBK+CXnhWL/vc0XeCADeP2YXbs3gWcI3Ia9vs5Bwqt/3SR0aR2HGUN4/Zv34ZvAs4ZuQ19d/H271+z5z81MoPn6aXrc6HYoJcZbwTUjrq9+HYzmnz7z8FFo6e9hf3ex0KCbEBTzhi0iUiOwQkZcCvbYJPyVhND/nQq7I826IYu2ZZpCcOMP/CrDfgXVNGNriTYJ9u0SFo5zhCYwckcBW2wHLDFJAE76IjARuAn4byHVN+Npc2kBhGM3PuZC5+Z6NzVWtjm8uX6DP8H8GfAO44F0kInK3iBSLSHFdXV3gIjMhp2/+fSjvbtVf8/JTaGjr4mhdm9OhmBAWsIQvIiuBWlXddrHHqeqDqlqkqkXp6ekBis6EopKq5rCv3/eZ672pzOr4ZjACeYa/CFglIseBJ4HlIvJYANc3YeaD+TlheIftufJSh5CeFGf9+BfR3evm+Z2V3Pnbzfzr8yW2PeR5RAdqIVX9J+CfAERkKfB1Vb0rUOub8LPFu39tuNfvAUSEuXkpdoZ/Hk1nuvnj+yd4ZNNxqps6yB2ewKajDby29yT/fstUrpmc6XSIQcP68E1I6ul1s/X46Ygo5/SZm59CVVMHFafPOB1K0PjtulLm/+db/NeaA+SnJfLQp4pY941lPHPvIoYlxPC5R4r58hM7aGjtdDrUoBCwM/yzqeo7wDtOrG3Cw96qZlo7eyIu4YOnjj9yxBCHo3HeltIGfvjKfpaMS+eb109kck7yB5+bOWo4L963mAfePcrP1x5m3eE6Hvr0FcwePcLBiJ1nZ/gmJIXj/PtLmZCZRHJ8tJV1gJaObr72512MThnCL++c/VfJvk9stIsvXz2OV758JUNio/nmX3bT3RvZY6YHnPBFJFFEovwRjDH9tdlbv89Iinc6lIBxueSDfvxI9+8v7aeqsZ2ffGQGiXEXL1SMy0zi+6uncLi2ld9vOBagCIPTJRO+iLhE5OMi8rKI1AIHgGoR2SciPxaRQv+Hacz/09Prpvj4aeZFUDmnzxV5KZTWt1Hb0uF0KI55c99J/lRczj1XFVCU179XeFdPyuSaSRn87M3DVDe1+znC4NWfM/y3gQI8HTZZqjpKVTOAxcBm4L9ExLptTMDsrWqmJcLq9336nvPm0sg8y29o7eRbz+xmYlYSX71m3IC+9l9vnkKvW/nhy5E72aU/Cf8aVf2Bqu5W1Q8KYKp6SlWfVtVbgT/5L0Rj/tqGo/UALIjAhD8lJ5mk+Gg2eb8HkURV+fazJTS39/DTj80kLnpgleVRKUO4d2khL+2uZsORyPv+Qf+6dL4E/PRiD1BVu8PBhw7UNLPuUD1xMS7iol3ERUcRH+Ni9ugRZCRHTs36QjYeaWBiVlJE9N+fKzrKxbz8FDYdjbwbsF7YVcWavTV864aJTMr+24u0/XHPVWN5ensF//J8Ca9+ZQmx0ZHVtzKghC8it6vqk32fEJFMYDbwpiV933hr/0m++MftdHT/bTdB2tBY/vDZuUzJGeZAZMGho7uXrcdPcee8MU6H4pgFBWm8ub+WysZ2cocnOB1OQLjdyv1vHmZKTjKfv3LsZR8nPiaK762azGcfLuZ3G47xhasKfBhl8OvPr7fRIpLkfftX53zuEeBjwOM+jSpCPbW1nLsf3cb4zCTWf3MZ275zDRu/tZy3v76UP909n9goF7c/uJniCB6Tu73sNJ09bhYVRl45p8/CAs9zj6Sz/LUHaimtb+PuJWOJcsmgjrV8YiYrJmfyv28d5mRzZF387k/CPwX8h4isBqJFZMlZn8tW1U8Df/BHcJFCVfn5W4f5xtO7WVSYxhOfn8/IEUNIHRpHzvAE8tMSmTc2lT//n4WkD43jroe28M7BWqfDdsSGo/VEedsTI9WEzCRGDImJqIT/m3Wl5AyL58Zp2T453ndumkR7dy+Pby7zyfFCRX8S/keAdcDngduAn4vIJ0XkG0AtgKq+7L8Qw1uvW/nu8yX85I1DfHhWLg99quiCfcW5wxN46gsLGJs2lM8/UszLu6sDHK3zNhxpYOao4STFxzgdimNcLmFBQSqbjtZHxHz8PRVNbDl2is8syicmyjc19zGpiSwdn86TW8sj6masS373VPU9VX1KVVeq6mvAR4GZQB6eXwJmEH725iEe23yCL1xVwE8+OuOS/6HThsbxxN3zmTlqOPc9sZ1X90RO0m/u6GZ3RSOLCiK3nNNnQUEaVU0dlDWE/1yd36wrZWhcNB+bO8qnx/34vDHUtnTy1v7IebXcnxuv/qpgpqoHVfUfVPVeVT12vseY/ik/dYZfv1fKLTNz+NYNE+nvt3FYQgyPfHYeU3OH8d3n90bMGNjNRxtwKywsTHM6FMf1taRuKg3vsk5lYzsv76nm9itGkezjV3XLJqSTlRzPH98/4dPjBrN+3XglIveJyOizPygisSKyXET+AHzKP+GFtx+tOYBL4Js3TBzw1ybERvHvt0yloa2T/33zsB+iCz4bjzYQH+Ni1ujhTofiOM9YiTg2hnkd/2HvKITPLM73+bGjo1zcPncU6w7XcSICXilB/xL+9UAv8ISIVHlHKhwDDgN3AD9T1Yf9GGNY2nr8FC/vruYLVxWQPezyWuumjxzOx4pG8fDG4xypbfFxhMFnw5F6rshLGfANN+FIpK+O3xC2dfyWjm6efL+cG6dl+6399GNXjEKAJ7ZGxll+f2r4Har6S1VdBIwBrgZmqeoYVf28qu7we5Rhxu1Wvv/iPrKHxXPPksH1AX/9ugkkxEbxvRf2he0PPkBtcweHa1tZbOWcDywsSKW+tZMjta1Oh+IXf9paTktnD5/zw9l9n+xhCSyfmMmfi8vp6gn/i7cDuuStqt2qWq2qjQAiYq+tL8MzOyrZU9nEN6+fSELs4M5W04bG8Q8rxrP+SD2v7a3xUYTBp2+cwiJL+B9YWOD5XoRjWaen183vNxxnbl4KM0b5N83cOX809a1dvL4vfH9++vQr4XtHIs8Vkc+KyE9E5DURqQSO+ze88NPW2cN/rznAjFHDWTUjxyfH/MT8MUzITOIHL+2nvavXJ8cMNhuONDB8SAyTL/OW+nA0KmXIB9v5hZvX9p6ksrGdz13pv7P7PkvGpZM7PIE/bgn/sk5/unSOA4eAHwKzgKPANDxlHTvDH6AH3j1KbUsn/7JyMq5B3jHYJzrKxfdWTaGysZ0H3j3qk2MGE1Vl45F6FoxN9dn3LFwsLEhlU2kDbnd4lfP+VFxOzrB4rp7k//1oo1zCHXNHsfFoA6V14Vke69OfM/wX8dxt+xtVvU9Vfwl0qmrkNK/6SFVjOw++V8qqGTnMGePbrdYWFKRy0/RsHnj3KOWnwqvj4HjDGaqaOqwd8zwWFKTS1N7Nvupmp0PxmZqmDtYfruPWOSMHPUahvz5aNIpol/BEmLdo9uei7X3ASuBGEdkqIjcA4XU6ESCPbCqjx6184/oJfjn+t2+chKrnRpVw0jfK1i7Y/q0FBX3z8cOnrPPMjgrcCrfOHhmwNTOS41kxOZO/bKugsyc8y6LQzxq+qpZ5Z+Z8Gs/dtVkissyPcYWdzp5eniou55pJGX7bgDpneAKrZ+bwVHE5p9u6/LKGEzYcqSdnWDx5qbZx97myhyUwNi0xbC7cqip/2VbBFXkjyEtLDOjaHy0axekz3aw7FL6z8vt70fYHIjJGVfeq6oeBZcC3ReTd/i4kIvEi8r6I7BKRvSLyb5cbdChaU1LDqbYuv4/1/fySsXR0u3ksTIZC9bqVTaUNLCxM6/edyJFmQUEqW0obwqKtcEd5I6V1bdw2J3Bn930WFaaRHB/NK2E8rqS/bZlfAV73dufcBmxT1WuA7w9grU5guarOwDOL53oRmT+wcEPX45tPMCZ1iN/LEuMzk7hqfDp/2FRGR3fovzTdVdFI45lurhxn5ZwLWTI+nbauXorLQn9s9l+2VZAQE8VN033TwTYQsdEurp2SxRv7ToZtWae/Cf+kqk4AfgSsBo6IyI+Biv4upB59l8BjvH8i4lrAwZoW3j9+ijvnjQ5Il8ndS8ZS39rJ8zsr/b6Wv63dX0uUS7hqfLrToQStxYVpxEQJ7xysczqUQeno7uXFXVXcMDWLoReYGOtvN03LpqWzh/WHw7Os09+ErwCq+raqfgKYDpwBSkRkcn8XE5EoEdmJZ6zyG6q65TyPuVtEikWkuK4utP8D9/njljJio13cNse30/4uZGFBKpOzk/nNumMh36639kAtc0aPYPiQWKdDCVqJcdHMy09l7YHQbpx7fd9JWjp6HCnn9Okr67wcpmWdAd1pKyIuEVkFPIpnp6vvAsf6+/Wq2quqM4GRwFwRmXqexzyoqkWqWpSeHvpndW2dPTyzvZKbpmWTkhiYpCUifH5JPkdqW3n3UOj+0qxuamdfdTPLJmY4HUrQWzohnSO1rSHdkvuXbRXkDk9gvoOb08dGu1gxOXzLOv1N+ENF5EdAKXA7cL+qTlTVH6lq+0AX9Y5meBvPYLaw9sKuKlo6e7hr/uhLP9iHVk7PISs5PqRbNN8+4PlldfUkS/iXstz7SzFUd0Krbmpn3eE6bp2d6/jNdTdNz6Klo+eDduBw0t+EfwqoBmar6sdVde1AFxKR9L7ZOyKSAKwADgz0OKFEVXlscxkTs5KYPdq3N1pdSkyUi88symPj0QZKKpsCuravrD1QS+7wBMZlDHU6lKCXn5bImNQhIVvWeWZ7Japwq4PlnD6LC9NJio/m5d3hN1unv334U1X1flUdTBtANp7Z+ruBrXhq+C8N4nhBb1dFE3urmrlz/hhHWgrvmDeaoXHR/DYEz/I7unvZcKSe5RMzrB2zH0SEZRMy2Hi0IeS6s1SVp7dVMDc/hTGpge29Px9PWSeTN/bVhEWr69l8s0FkP6jqblWdparTvb9ABtLSGZIe21xGYmwUH5qV68j6yfEx3H7FKF7cXU1104Arb47aXNpAe3cvy62c02/LJmbQ2eMOuWFq2080Ulrfxm0BvLP2UlZOz6Y5DMs6AUv4kaapvZsXd1Vxy6xcx1rMAD61MA+3Kk+E2CTAtw/UEh/j+mArP3Np8/JTSIiJ4u0Qq+M/s72C+BgXN07PdjqUD3xQ1gmzbh1L+H7yWkkNnT1uPloUmFbMCxmVMoRlEzJ4Yms53b2h8fJUVXnrQC2LCtKIj7HdrforPiaKRYWe9sxQ2Qyns8fTe3/9FOd678+nr6zz+t7wKutYwveTF3dXMSZ1CNNHDnM6FO6aP5q6lk5e33vS6VD65UhtKxWn260d8zIsnZBBxel2jobImN+1+2tp7ujhw0FUzulz0zRvWedo+JR1LOH7QX1rJxuPNnDz9JyguOB41fgMRo5ICJn5On2dJsst4Q9Y3y/JvpbWYPf09koyk+OCciezxePSSIqL5pXd4VPWsYTvB6+W1NDrVm720Y5WgxXlEj4+bzSbShtCYrPztw7UMjEriRw/bVwdznKHJzAhMykk2jMbWjt552Att8zKDdjc+4GIi47ylHX2nQyZcuilWML3gxd3VTEuYygTspKcDuUDHy0aRWyUi8c2B/fF26Yz3WwrO21n94OwdGI6W4+foqWj2+lQLurFXVX0uJUPzwq+ck6fa6dk0dTezdbjoT+YDizh+1x1Uztbj58KmrP7PmlD47hhWhZPb6vgTFeP0+Fc0HuH6+h1q91dOwjLJ2TQ49agbyl8enslU3OTg+rE6FxLxqcRF+3ijX2hcf3rUizh+9jLu6tR9fTxBpu75o+hpbOHF3ZWOR3KBa09UMuIITHMHBXYO5PDyewxI0iKjw7qss6hky3sqWwK6rN7gCGx0SwuTOONfSdDpvPpYizh+9iLu6uZmpvM2PTgGwdQNGYEE7OSeHRzWVD+5+3s6WXtgVqWTsgIyppuqIiJcrF0QgZv7q8N2trzM9sriXYJq2YG1yvh81kxOZOK0+0cqAn+61+XYgnfh040nGFXeSM3O7B5Q3+ICHfOH8PeqmZ2ljc6Hc7fePdgHU3t3awKsnJYKFo1I4dTbV1BOde91608t6OSpRPSSRsa53Q4l3T1pExECIuyjiV8H3ppj6dUclMQlnP6fGhWLomxUTwahC2az++sIiUxlsW2u9WgXTU+nWEJMTwXhJvgbDraQE1zR1D23p9PelIcs0YNt4Rv/tqLu6qZPXq43zYp94WhcdF8aHYuL+2upqG10+lwPtDS0c2b+0+ycno2MVH233KwYqNd3Dgtm9f3nqStM7gu0j+zvYLk+OiQ6sRaMTmLPZVNVDWG1kyqc9lPlo8cqW1hf3Vz0HXnnM+nFuTR1ePmya3lTofygTXeURSrZzozaC4c3TIzh/buXt7cHzxnpi0d3bxaUsPKGTkhNTZjxeRMgKD6Xl4OS/g+8uKuakQ8t2MHu3GZSSwuTOPRTWVBc1Hv+Z1VjE4ZwuzRw50OJWxckZdCzrB4ntsRPGWd53ZU0t7dy8ccnjE1UIUZQxmblhjyZR1L+D6gqry4u4r5+alkJMc7HU6/fGZRHjXNHbxa4vwmD7XNHWw8Ws/qmcExiiJcuFzCzTNzeO9wfVCU7zwbAp1gWu4wZowKvV/sKyZnsrm0geYgv6HtYizh+8Dh2lZK69qCarzrpSybkEFe6hAe3tDvLYn95oVdVbgVK+f4wS0zc+l1a1CM+d16/DQHT7bwifljnA7lsqyYnEl3r/LOwdCYU3Q+lvB9YE1JDSJwnbfOFwpcLuFTC/PYfqKRXQ63aD6/s4qpuckU2laGPjcpO5kJmUk8HwQ32z22uYzk+OiQuM51PrNGjyA1MTakyzqW8H1gTUkNc0aPCJlyTp/b5oxkaFw0v3fwLP9oXSt7Kpu4xc7u/WbVzBy2lZ2m/NQZx2Koa+nk1ZJqbpszioTY0LlYe7Yol3D1pAzeOVAbsjPyLeEP0omGM+yrbua6KVlOhzJgSfEx3DZnJC/vqaa2ucORGJX2p+MAABaWSURBVJ7fUYkIIXvWFwpWe+9mfd7Bnvynisvp7lXunD/asRh8YcXkLFo6e9hcGlrbSPaxhD9Ir+31XPQMxYQP8OmFefS4lccc2AJRVXl+VxULC1LJDLFXR6Fk5IghXJE3gud2VjkyUqPXrfxxywkWFaZSEIQjRwZicWEa8TGhO0wtYAlfREaJyNsisk9E9orIVwK1tj+t2VvD5OxkRqcG781WF5OXlsiyCRn8cUsZnT29AV17Z3kjZQ1n7GJtAKyemcuR2lb2VTcHfO13DtZS2djOXfNC82Lt2RJio1gyLp039p3E7Q6+eVSXEsgz/B7ga6o6GZgPfFFEJgdwfZ+rbe5gW9lprp8ammf3fT6zKI/61i5e2hXYTo5nd1QSG+0K+e9fKLhxWjbRLuGZ7YEv6zy6uYzM5DiuCaGmhou5dkoWNc0d7KlscjqUAQtYwlfValXd7n27BdgPhPSp3evel3WhnrAWF6ZRmDGU364/FrCzllNtXfy5uIKV07NJjo8JyJqRLCUxlhumZfOnreU0nQlcH/mJhjO8e6iO268YHTYjM66Z5Jnm2lfODSWO/AuISB4wC9hyns/dLSLFIlJcVxfc/a6v7a1hbFoi40K8nVBEuHdpAfurm3mlJDBn+Q9vOEZHTy/3Li0IyHoG7l1aQGtnD49sOh6wNR9/vwyXCHfMDe2LtWcbPiSWefkplvD7Q0SGAk8DX1XVvykoquqDqlqkqkXp6emBDq/fGs90seloA9dOyQqLu0NXz8xlfOZQ/uf1Q/T4edxCS0c3D288zvVTsijMCN7djsLNpOxklk/M4HcbjgVk17Pmjm6efL+cFZMyyRoWXhflr5uSxdG6No7UtjodyoAENOGLSAyeZP+4qj4TyLV97a39tfS4NeTLOX2iXMLXrp1AaX0bT2+v8Otaj20+QXNHD/cuLfTrOuZvfXFZAafPdPPE+/4fnPfrd4/S1N7Nl5aH379z3zC11/eF1ll+ILt0BHgI2K+q/xOodf1lzd4asofFMz13mNOh+My1kzOZMWo4P3vzMB3d/unY6eju5aH1pSwZn860keHzvQsVc8akMC8/hd+8V+rXrqza5g4eWn+MVTNymBpGPyN9coYnMH3kMF7bG1rtmYE8w18EfAJYLiI7vX9uDOD6PtPW2cN7h+q4bkoWrjDaik9E+MZ1E6hu6uAxP22Q8lRxOfWtXXzRaveO+eKyQmqaO/w6RfP+tw7T06t87drxflvDaddNyWJXeSM1Tc7ctHg5Atmls15VRVWnq+pM759XArW+L717qI7OHnfI3mx1MYsK01hUmMov3zlKq483zujudfPrd0spGjOCufkpPj226b8rx6UxNTeZX71zlF4/dGUdq2/jya3lfHzeaMakJvr8+MHiuimhV9YJjz6pAFtTUkNKYixX5I1wOhS/+MfrJnKqrYuH1vl2xs5zOyqpbGzni8sKw+JCd6gSEb64tJDjDWd4xQ9TNH/y+kHiol3ct3ycz48dTAozkhibnsjrIVTWsYQ/QJ09vaw9UMs1kzKIDpO+4nPNHDWc66Zk8pt1pZxq6/LJMXvdyq/ePcqk7GSWTgje7qtIcd2ULArSE/nF20d8Om5hT0UTL+2u5u8W55OeFPwblA/WdVOy2FzaENB7GwYjPDOWH60/XE9rZw83hMDOVoPxtWsn0NbVw8/ePOST4720u4rSuja+uKzAzu6DgMsl/J+lhRyoafHphcf/fu0AI4bEcPeSsT47ZjC7bkoWPW7lrQOhcZZvCX+AXi2pISk+mkUFaU6H4lfjM5P41II8HtlUxgu7BjdLvayhje8+V8LU3GRumBrevyhDyeqZOYzPHMo/P7vHJxceNxypZ93her64rJCkCLl7enruMDKT40LmJixL+APQ3evmjX0nuWZSJrHR4f+t++cbJ3FF3gi+8Zdd7Ku6vKFb7V293PPoNkSEX905h6gw6moKdTFRLn5552w6unv50h+3D2p/49NtXXznuRJyhydwV4juaHU5XC7h2slZvHuojvauwA4fvBzhn7V8aNPRBprau8PmZqtLiY128Ys7ZzMsIYZ7Hium8czA6vmqyj8/u4eDJ1v42e0zGZUSmhNFw1lhRhL/+eFpFJed5v977eBlHaOju5fPP1JMZWM7998+k/iY0Nzg5HJdNyWLjm436w4H9ygYsIQ/IK+W1DAkNoqrxkfORceMpHh+ddccTjZ1ct8TOwbUxvfY5jKe3VHJV68ez7IJGX6M0gzG6pm53DV/NL9+r3TAc97dbuVrf95FcdlpfvrRmRTlRV677byxKQxLiOHVkuAv61jC76det/LGvhqWTcyIuDOY2aNH8P3VU1h3uJ4f9/MscFvZab7/0j6WT8zgvjC8tT7cfOemyUzNTeZrT+0c0FaI//XaAV7eXc0/3TCRm6ZH5vWZmCgXN0zN4vW9NUFf1rGE309bj5+ivrWLGyKknHOu2+eO5uPzRvPAu0f57zUHaGjtPO/jVJVtZae49/FtZA9L4KcfnRlWdyOHq/iYKH758TkocO/j22lqv3Sb4aOby/j1u6XcNX90xHTlXMiqmTm0dfUGfbeOJfx+enVPNXHRroguTXzv5incPCOHX75zlIU/Wsu3n93D8fo2AFo7e3hscxk33L+OW3+1iY5uNw/cNYdhQyKjWyMcjE4dwk8+MoOSqiYW/2gt//P6wfNet6k4fYb/u/Yw//p8CcsnZvC9m6dEfKvtvPxUMpPjeG7H4Dra/E2c2OOyv4qKirS4uNjpMHC7lQU/eosZI4fz4CeLnA7HcUdqW/ntulKe2V5Jt9vN/PxUdlc00tbVy+TsZO6aP4bVM3NIjIt2OlRzGfZWNfHzt46wZm8NQ+Oi+dTCMayemcu6w/W8tLuKHScaAc+IhgfummP/zl4/fHkfD288ztZvX8PwIbGOxSEi21T1vInKEn4/bCs7za2/2shPPzaDD80a6XQ4QaO2pYM/bDzOi7uqKcobwV3zxzBr1PCIP9sLFwdqmvn52iO8sqeavjQxOTuZlTOyWTktJ2T3cfaXksomVv58Pf/54WmObvhysYRvv5r7YU1JNTFRwvKJ4bEnp69kJMXzj9dN5B+vm+h0KMYPJmYl84uPz+bQyRY2lzawuDCNsemhvbubP03JSWZseiLP76wM2h2+LOFfgqryyp4aFhWmMSzB6tEm8ozPTGJ8pu1MdikiwuoZufzsrUNUN7WTPSzB6ZD+hl20vYSSymYqG9u50UYCGGMuYdXMHFThpV2B2Rt6oCzhX8KrJdVEueSDLc2MMeZC8tMSmTFyGM/v8t/mMoNhCf8i3G7lhV1VLCxIZUSic1fdjTGhY9XMXEoqm4Nyg3NL+Bex7cRpKk6386FZuU6HYowJETdPz0YEXtgZfGf5lvAv4tkdlSTERIXlVobGGP/ISI5nYUEqz++q8unmMr5gCf8CunrcvLy7mmunZNqNJcaYAVk9I5eyhjPsLG90OpS/ErCELyK/E5FaESkJ1JqD8c7BWprau7nFyjnGmAG6floW8TEunny/3OlQ/kogz/AfBq4P4HqD8tzOSlITY7myMLx3tjLG+F5yfAwfmjWS53ZW+mxfaF8IWMJX1feAU4FabzCa2rt5c38tN8/ICduNyo0x/vWZRXl09rh54v0TTofyActm57GmpJquHrd15xhjLtv4zCQWF6bx6KayQW0f6UtBl/BF5G4RKRaR4ro6Z7YMe3ZHJWPTEpk+cpgj6xtjwsOnF+ZR09zBmiDZDSvoEr6qPqiqRapalJ4e+K0EKxvb2Vx6iltm5drUR2PMoCyfmMGY1CE8vPG406EAQZjwnfbCTs8GBrfMtHKOMWZwXC7hkwvy2FZ2mt0VzrdoBrIt8wlgEzBBRCpE5O8CtXZ/qSrP7qhgzpgRNuvbGOMTHykaSWJsFL/fcNzpUALapXOHqmaraoyqjlTVhwK1dn/tr27h0MlW6703xvhMcnwMHykaxUu7q6ht6XA0FivpnOVPW08QEyXcNM1GIRtjfOeTC8bQ3as8vtnZFk1L+F5N7d38eVsFN8/IIcUmYxpjfGhs+lCWTUjn8S1ldPb0OhaHJXyvPxeXc6arl88uync6FGNMGPrs4nzqW7t4dFOZYzFYwgd63crDG48zNy+FqbnWe2+M8b3FhWksm5DOT984RE2TM7V8S/jAG/tOUnG6nc8uznM6FGNMmBIRvrdqCt1u5Qcv73MkBkv4wO82HGPkiARWTLa598YY/xmTmsi9Swt4eXc16w/XB3z9iE/4JZVNvH/sFJ9akEeUy+6sNcb41xeuKmBM6hD+5fmSgF/AjfiE/7sNxxgSG8VHrxjldCjGmAgQHxPFv62aQml9G795rzSga0d0wq9t6eClXdV8ZM5IhiXEOB2OMSZCLJ2QwQ1Ts/j52iOUnzoTsHUjOuE/vvkEXb1uPrUwz+lQjDER5rsrJxPlEr73wt6A7X0bsQm/o7uXx7eUsXxiBmPThzodjjEmwuQMT+DvrxnPWwdq+dbTe+gJwMz8iN2d+/EtJ6hv7bIbrYwxjvnclfk0d3Tz87VHaGjr5Od3zCYhNspv60XkGf7J5g5++sYhrhqfzqLCVKfDMcZEKBHha9dO4Aerp/DWgVruemgLjWf8twduRCb8H768n65eN/+2aoptcmKMcdwnFuTxi4/PZk9FEx95YBNVje1+WSfiEv7GI/W8sKuKL1xVQF5aotPhGGMMADdOy+YPn51LTVMHt/1qI22dPT5fI6Jq+F09br77fAmjUhK4d2mB0+EYY8xfWVCQyp/uWcCO8tMkxvk+PUdUwn9o/TGO1rXxu08XER/jvwsjxhhzuSbnJDM5J9kvx46Ykk5lYzv/+9Zhrp2cyfKJmU6HY4wxARcxCf8HL+5DUf7l5slOh2KMMY4I+4Svqvzo1QOs2VvDfcvHMXKEbU5ujIlMYV3D73Ur3352D09uLefOeaP5wlV2odYYE7kCeoYvIteLyEEROSIi3/LnWp09vXzpj9t5cms59y0v5N9vmWrjj40xES1gZ/giEgX8AlgBVABbReQFVfX51i+tnT3c82gxG4408N2Vk/m7xTY+wRhjAlnSmQscUdVSABF5ElgN+DThN7V388mHtlBS1cxPPjKDW+eM9OXhjTEmZAUy4ecC5We9XwHMO/dBInI3cDfA6NGjB7xIYmwUeWmJ3Ld8HNdMtvZLY4zpE3QXbVX1QeBBgKKiogEPiY6OcnH/7bN8HpcxxoS6QF60rQTO3kdwpPdjxhhjAiCQCX8rME5E8kUkFrgdeCGA6xtjTEQLWElHVXtE5EvAa0AU8DtV3Ruo9Y0xJtIFtIavqq8ArwRyTWOMMR5hP1rBGGOMhyV8Y4yJEJbwjTEmQljCN8aYCCGqA763KWBEpA4o89Hh0oB6Hx3LSeHwPOw5BAd7DsHDl89jjKqmn+8TQZ3wfUlEilW1yOk4Biscnoc9h+BgzyF4BOp5WEnHGGMihCV8Y4yJEJGU8B90OgAfCYfnYc8hONhzCB4BeR4RU8M3xphIF0ln+MYYE9Es4RtjTISIqIQvIj8Qkd0islNEXheRHKdjGigR+bGIHPA+j2dFZLjTMQ2UiHxERPaKiFtEQqqlTkSuF5GDInJERL7ldDyXQ0R+JyK1IlLidCyXS0RGicjbIrLP+3/pK07HNFAiEi8i74vILu9z+De/rxlJNXwRSVbVZu/bXwYmq+oXHA5rQETkWmCtd9z0fwGo6jcdDmtARGQS4AZ+DXxdVYsdDqlfRCQKOASswLNF51bgDlX16b7M/iYiS4BW4BFVnep0PJdDRLKBbFXdLiJJwDbgllD6txARARJVtVVEYoD1wFdUdbO/1oyoM/y+ZO+VCITcbztVfV1Ve7zvbsazc1hIUdX9qnrQ6Tguw1zgiKqWqmoX8CSw2uGYBkxV3wNOOR3HYKhqtapu977dAuzHs292yFCPVu+7Md4/fs1JEZXwAUTkhyJSDtwJ/IvT8QzSZ4FXnQ4iguQC5We9X0GIJZlwJCJ5wCxgi7ORDJyIRInITqAWeENV/focwi7hi8ibIlJynj+rAVT126o6Cngc+JKz0Z7fpZ6D9zHfBnrwPI+g05/nYMxgichQ4Gngq+e8gg8JqtqrqjPxvFKfKyJ+LbEFdMerQFDVa/r50Mfx7L71r34M57Jc6jmIyKeBlcDVGqQXYQbw7xBKKoFRZ70/0vsx4wBv3ftp4HFVfcbpeAZDVRtF5G3gesBvF9PD7gz/YkRk3FnvrgYOOBXL5RKR64FvAKtU9YzT8USYrcA4EckXkVjgduAFh2OKSN4Lng8B+1X1f5yO53KISHpfl52IJOBpBvBrToq0Lp2ngQl4OkTKgC+oakidoYnIESAOaPB+aHMIdhp9CPg5kA40AjtV9Tpno+ofEbkR+BkQBfxOVX/ocEgDJiJPAEvxjOQ9Cfyrqj7kaFADJCKLgXXAHjw/zwD/7N03OySIyHTgD3j+L7mAp1T1+35dM5ISvjHGRLKIKukYY0wks4RvjDERwhK+McZECEv4xhgTISzhG2NMhLCEb4wxEcISvjHGRAhL+CaoiEivd7+Cvd454V8TEZf3cxu9f+cNZpa7iHxPRL5+GV/XepHP3SIiKiITLzeu/qzTj6+9yjvrvldEjonI1wYbjwkflvBNsGlX1ZmqOgXPreY34J13pKoL/bmweFzuz8QdeOaZ3+HDkC5HFvBnIFVV81X1Jw7HY4KIJXwTtFS1Frgb+JI3GZ995hslIr/xvhJ43TuLBBG5y7uL0E4R+bV30xJE5NsickhE1uMZr4H343neHawewTO0apSIPCci27zHvvtScXonNi4G/g7PfJ2zj73/AnF+17vuehF54nyvOC70XC7hk8CbQFM/HmsijCV8E9RUtRTPrJGMcz41DviF95VAI3CrdyetjwGLvCNne4E7RWQOnkQ8E7gRuOI8x/qlqk5R1TLgs6o6BygCviwiqZcIczWwRlUPAQ3e9S4W5xXArcAMPK9g/mabxws9l0vEAZ4ZRY8CjSLy8X483kSQsBuPbCLGMVXd6X17G5AHDAfmAFs9wxRJwLOxRArwbN90URE5d8Jl2Tnbyn3ZO+ANPOOQx/H/htWdzx3A/d63n/S+v+0icaYBz6tqB9AhIi+e55hXX+C5XJD3+sF/AzcD7wTr6GzjHEv4JqiJyFg8Z7fnJrvOs97uxZMQBfiDqv7TOcf46iWWaTvrsUuBa4AFqnpGRN4B4i8SXwqwHJgmIorn1YiKyD9eJM7+OO9zuYR7gP9R1bcH8DUmglhJxwQtEUkHHgD+bz/PVt8CbhORDO/Xp4jIGOA94BYRSRDPhtc3X+QYw4DT3mQ/EZh/iTVvAx5V1TGqmufdTe0YcOVFvmYDcLOIxHvr/ysH8FwQkbdE5HxbK8bjuWhrzHlZwjfBJqGvLRPPxcfXgX/rzxeq6j7gO8DrIrIbeAPI9m52/SdgF549gLde5DBrgGgR2Q/8CM9G8RdzB/DsOR97mot066jqVjwbp+z2xrOHcy6yXui5eLuICjn/JuQ/BlaIZyvJN0Qk+xKxmwhj8/CNcYCIDFXVVhEZgucVyN3eX0yX+rqpeC4q/8MlHvcHPBtqvOybiE04sBq+Mc54UEQm4ynD/KE/yR5AVUuASyX7lUAinldIxnzAzvCNMSZCWA3fGGMihCV8Y4yJEJbwjTEmQljCN8aYCGEJ3xhjIoQlfGOMiRCW8I0xJkL8/yQm/PaIT5GRAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "ax.set_xlabel(r\"Dihedral Angle, $\\xi$\")\n",
+    "ax.set_ylabel(r\"$\\nabla A(\\xi)$\")\n",
+    "\n",
+    "ax.plot(mesh, A)\n",
+    "plt.gca()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8657b0b7",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "Butane-FUNN.ipynb",
+   "provenance": []
+  },
+  "jupytext": {
+   "formats": "ipynb,md",
+   "main_language": "python"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
The butane FUNN example was still using the `method.run` instead of `pysages.run` + `pysages.analyze`.