### PR TITLE
Use numpy numpy arrays in results, instead of JAX.numpy arrays

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 100
 per-file-ignores = __init__.py:F401
-ignore=F811
+ignore=F811,W503

--- a/docs/source/pysages_wordlist.txt
+++ b/docs/source/pysages_wordlist.txt
@@ -47,3 +47,4 @@ hoomd
 SimulationContext
 decompositions
 conda
+numpyfying

--- a/pysages/methods/abf.py
+++ b/pysages/methods/abf.py
@@ -31,7 +31,7 @@ from pysages.approxfun.core import scale as _scale
 from pysages.grids import build_indexer
 from pysages.methods.core import GriddedSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
-from pysages.methods.utils import numpyfy_dictionay
+from pysages.methods.utils import numpyfy_dictionary
 from pysages.ml.models import MLP
 from pysages.ml.objectives import GradientsSSE, L2Regularization
 from pysages.ml.optimizers import LevenbergMarquardt
@@ -345,4 +345,4 @@ def analyze(result: Result[ABF], **kwargs):
         mesh=inputs,
         fes_fn=fes_fn,
     )
-    return numpyfy_dictionay(ana_result)
+    return numpyfy_dictionary(ana_result)

--- a/pysages/methods/abf.py
+++ b/pysages/methods/abf.py
@@ -31,7 +31,7 @@ from pysages.approxfun.core import scale as _scale
 from pysages.grids import build_indexer
 from pysages.methods.core import GriddedSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
-from pysages.methods.utils import numpyfy_dictionary
+from pysages.methods.utils import numpyfy_vals
 from pysages.ml.models import MLP
 from pysages.ml.objectives import GradientsSSE, L2Regularization
 from pysages.ml.optimizers import LevenbergMarquardt
@@ -345,4 +345,4 @@ def analyze(result: Result[ABF], **kwargs):
         mesh=inputs,
         fes_fn=fes_fn,
     )
-    return numpyfy_dictionary(ana_result)
+    return numpyfy_vals(ana_result)

--- a/pysages/methods/abf.py
+++ b/pysages/methods/abf.py
@@ -20,7 +20,6 @@ second order backward finite difference in the simulation time step.
 from functools import partial
 from typing import NamedTuple
 
-import numpy
 from jax import jit
 from jax import numpy as np
 from jax import vmap
@@ -32,6 +31,7 @@ from pysages.approxfun.core import scale as _scale
 from pysages.grids import build_indexer
 from pysages.methods.core import GriddedSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
+from pysages.methods.utils import numpyfy_dictionay
 from pysages.ml.models import MLP
 from pysages.ml.objectives import GradientsSSE, L2Regularization
 from pysages.ml.optimizers import LevenbergMarquardt
@@ -338,10 +338,11 @@ def analyze(result: Result[ABF], **kwargs):
 
     fes_fn = build_fes_fn(state)
 
-    return dict(
-        histogram=numpy.asarray(state.hist),
-        mean_force=numpy.asarray(average_forces(state)),
-        free_energy=numpy.asarray(fes_fn(inputs).reshape(grid.shape)),
-        mesh=numpy.asarray(inputs),
-        fes_fn=numpy.asarray(fes_fn),
+    ana_result = dict(
+        histogram=state.hist,
+        mean_force=average_forces(state),
+        free_energy=fes_fn(inputs).reshape(grid.shape),
+        mesh=inputs,
+        fes_fn=fes_fn,
     )
+    return numpyfy_dictionay(ana_result)

--- a/pysages/methods/abf.py
+++ b/pysages/methods/abf.py
@@ -20,6 +20,7 @@ second order backward finite difference in the simulation time step.
 from functools import partial
 from typing import NamedTuple
 
+import numpy
 from jax import jit
 from jax import numpy as np
 from jax import vmap
@@ -338,9 +339,9 @@ def analyze(result: Result[ABF], **kwargs):
     fes_fn = build_fes_fn(state)
 
     return dict(
-        histogram=state.hist,
-        mean_force=average_forces(state),
-        free_energy=fes_fn(inputs).reshape(grid.shape),
-        mesh=inputs,
-        fes_fn=fes_fn,
+        histogram=numpy.asarray(state.hist),
+        mean_force=numpy.asarray(average_forces(state)),
+        free_energy=numpy.asarray(fes_fn(inputs).reshape(grid.shape)),
+        mesh=numpy.asarray(inputs),
+        fes_fn=numpy.asarray(fes_fn),
     )

--- a/pysages/methods/ann.py
+++ b/pysages/methods/ann.py
@@ -26,7 +26,7 @@ from pysages.approxfun import compute_mesh
 from pysages.approxfun import scale as _scale
 from pysages.grids import build_indexer
 from pysages.methods.core import NNSamplingMethod, Result, generalize
-from pysages.methods.utils import numpyfy_dictionary
+from pysages.methods.utils import numpyfy_vals
 from pysages.ml.models import MLP
 from pysages.ml.objectives import L2Regularization
 from pysages.ml.optimizers import LevenbergMarquardt
@@ -311,4 +311,4 @@ def analyze(result: Result[ANN]):
         nn=first_or_all(nns),
         fes_fn=first_or_all(fes_fns),
     )
-    return numpyfy_dictionary(ana_result)
+    return numpyfy_vals(ana_result)

--- a/pysages/methods/ann.py
+++ b/pysages/methods/ann.py
@@ -17,6 +17,7 @@ as biasing force for the simulation.
 from functools import partial
 from typing import NamedTuple
 
+import numpy
 from jax import grad, jit
 from jax import numpy as np
 from jax import vmap
@@ -304,9 +305,9 @@ def analyze(result: Result[ANN]):
         fes_fns.append(build_fes_fn(s.nn))
 
     return dict(
-        histogram=first_or_all(histograms),
-        free_energy=first_or_all(free_energies),
-        mesh=mesh,
-        nn=first_or_all(nns),
-        fes_fn=first_or_all(fes_fns),
+        histogram=numpy.asarray(first_or_all(histograms)),
+        free_energy=numpy.asarray(first_or_all(free_energies)),
+        mesh=numpy.asarray(mesh),
+        nn=numpy.asarray(first_or_all(nns)),
+        fes_fn=numpy.asarray(first_or_all(fes_fns)),
     )

--- a/pysages/methods/ann.py
+++ b/pysages/methods/ann.py
@@ -17,7 +17,6 @@ as biasing force for the simulation.
 from functools import partial
 from typing import NamedTuple
 
-import numpy
 from jax import grad, jit
 from jax import numpy as np
 from jax import vmap
@@ -27,6 +26,7 @@ from pysages.approxfun import compute_mesh
 from pysages.approxfun import scale as _scale
 from pysages.grids import build_indexer
 from pysages.methods.core import NNSamplingMethod, Result, generalize
+from pysages.methods.utils import numpyfy_dictionary
 from pysages.ml.models import MLP
 from pysages.ml.objectives import L2Regularization
 from pysages.ml.optimizers import LevenbergMarquardt
@@ -304,10 +304,11 @@ def analyze(result: Result[ANN]):
         nns.append(s.nn)
         fes_fns.append(build_fes_fn(s.nn))
 
-    return dict(
-        histogram=numpy.asarray(first_or_all(histograms)),
-        free_energy=numpy.asarray(first_or_all(free_energies)),
-        mesh=numpy.asarray(mesh),
-        nn=numpy.asarray(first_or_all(nns)),
-        fes_fn=numpy.asarray(first_or_all(fes_fns)),
+    ana_result = dict(
+        histogram=first_or_all(histograms),
+        free_energy=first_or_all(free_energies),
+        mesh=mesh,
+        nn=first_or_all(nns),
+        fes_fn=first_or_all(fes_fns),
     )
+    return numpyfy_dictionary(ana_result)

--- a/pysages/methods/cff.py
+++ b/pysages/methods/cff.py
@@ -15,7 +15,6 @@ two neural networks to approximate the free energy and its derivatives.
 from functools import partial
 from typing import NamedTuple, Tuple
 
-import numpy
 from jax import jit
 from jax import numpy as np
 from jax import vmap
@@ -27,6 +26,7 @@ from pysages.approxfun import scale as _scale
 from pysages.grids import build_indexer
 from pysages.methods.core import NNSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
+from pysages.methods.utils import numpyfy_dictionary
 from pysages.ml.models import MLP
 from pysages.ml.objectives import L2Regularization, Sobolev1SSE
 from pysages.ml.optimizers import LevenbergMarquardt
@@ -413,12 +413,13 @@ def analyze(result: Result[CFF]):
         fnns.append(s.fnn)
         fes_fns.append(build_fes_fn(s.nn))
 
-    return dict(
-        histogram=numpy.asarray(histograms),
-        mean_force=numpy.asarray(mean_forces),
-        free_energy=numpy.asarray(free_energies),
-        mesh=numpy.asarray(mesh),
-        nn=numpy.asarray(nns),
-        fnn=numpy.asarray(fnns),
-        fes_fn=numpy.asarray(fes_fns),
+    ana_result = dict(
+        histogram=histograms,
+        mean_force=mean_forces,
+        free_energy=free_energies,
+        mesh=mesh,
+        nn=nns,
+        fnn=fnns,
+        fes_fn=fes_fns,
     )
+    return numpyfy_dictionary(ana_result)

--- a/pysages/methods/cff.py
+++ b/pysages/methods/cff.py
@@ -26,7 +26,7 @@ from pysages.approxfun import scale as _scale
 from pysages.grids import build_indexer
 from pysages.methods.core import NNSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
-from pysages.methods.utils import numpyfy_dictionary
+from pysages.methods.utils import numpyfy_vals
 from pysages.ml.models import MLP
 from pysages.ml.objectives import L2Regularization, Sobolev1SSE
 from pysages.ml.optimizers import LevenbergMarquardt
@@ -422,4 +422,4 @@ def analyze(result: Result[CFF]):
         fnn=fnns,
         fes_fn=fes_fns,
     )
-    return numpyfy_dictionary(ana_result)
+    return numpyfy_vals(ana_result)

--- a/pysages/methods/cff.py
+++ b/pysages/methods/cff.py
@@ -15,6 +15,7 @@ two neural networks to approximate the free energy and its derivatives.
 from functools import partial
 from typing import NamedTuple, Tuple
 
+import numpy
 from jax import jit
 from jax import numpy as np
 from jax import vmap
@@ -413,11 +414,11 @@ def analyze(result: Result[CFF]):
         fes_fns.append(build_fes_fn(s.nn))
 
     return dict(
-        histogram=histograms,
-        mean_force=mean_forces,
-        free_energy=free_energies,
-        mesh=mesh,
-        nn=nns,
-        fnn=fnns,
-        fes_fn=fes_fns,
+        histogram=numpy.asarray(histograms),
+        mean_force=numpy.asarray(mean_forces),
+        free_energy=numpy.asarray(free_energies),
+        mesh=numpy.asarray(mesh),
+        nn=numpy.asarray(nns),
+        fnn=numpy.asarray(fnns),
+        fes_fn=numpy.asarray(fes_fns),
     )

--- a/pysages/methods/funn.py
+++ b/pysages/methods/funn.py
@@ -29,7 +29,7 @@ from pysages.approxfun import scale as _scale
 from pysages.grids import build_indexer
 from pysages.methods.core import NNSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
-from pysages.methods.utils import numpyfy_dictionary
+from pysages.methods.utils import numpyfy_vals
 from pysages.ml.models import MLP
 from pysages.ml.objectives import GradientsSSE, L2Regularization
 from pysages.ml.optimizers import LevenbergMarquardt
@@ -389,4 +389,4 @@ def analyze(result: Result[FUNN]):
         nn=first_or_all(nns),
         fes_fn=first_or_all(fes_fns),
     )
-    return numpyfy_dictionary(ana_result)
+    return numpyfy_vals(ana_result)

--- a/pysages/methods/funn.py
+++ b/pysages/methods/funn.py
@@ -18,7 +18,6 @@ appropriate method.
 from functools import partial
 from typing import NamedTuple, Tuple
 
-import numpy
 from jax import jit
 from jax import numpy as np
 from jax import vmap
@@ -30,6 +29,7 @@ from pysages.approxfun import scale as _scale
 from pysages.grids import build_indexer
 from pysages.methods.core import NNSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
+from pysages.methods.utils import numpyfy_dictionary
 from pysages.ml.models import MLP
 from pysages.ml.objectives import GradientsSSE, L2Regularization
 from pysages.ml.optimizers import LevenbergMarquardt
@@ -381,11 +381,12 @@ def analyze(result: Result[FUNN]):
         nns.append(s.nn)
         fes_fns.append(fes_fn)
 
-    return dict(
-        histogram=numpy.asarray(first_or_all(hists)),
-        mean_force=numpy.asarray(first_or_all(mean_forces)),
-        free_energy=numpy.asarray(first_or_all(free_energies)),
-        mesh=numpy.asarray(mesh),
-        nn=numpy.asarray(first_or_all(nns)),
-        fes_fn=numpy.asarray(first_or_all(fes_fns)),
+    ana_result = dict(
+        histogram=first_or_all(hists),
+        mean_force=first_or_all(mean_forces),
+        free_energy=first_or_all(free_energies),
+        mesh=mesh,
+        nn=first_or_all(nns),
+        fes_fn=first_or_all(fes_fns),
     )
+    return numpyfy_dictionary(ana_result)

--- a/pysages/methods/funn.py
+++ b/pysages/methods/funn.py
@@ -18,6 +18,7 @@ appropriate method.
 from functools import partial
 from typing import NamedTuple, Tuple
 
+import numpy
 from jax import jit
 from jax import numpy as np
 from jax import vmap
@@ -381,10 +382,10 @@ def analyze(result: Result[FUNN]):
         fes_fns.append(fes_fn)
 
     return dict(
-        histogram=first_or_all(hists),
-        mean_force=first_or_all(mean_forces),
-        free_energy=first_or_all(free_energies),
-        mesh=mesh,
-        nn=first_or_all(nns),
-        fes_fn=first_or_all(fes_fns),
+        histogram=numpy.asarray(first_or_all(hists)),
+        mean_force=numpy.asarray(first_or_all(mean_forces)),
+        free_energy=numpy.asarray(first_or_all(free_energies)),
+        mesh=numpy.asarray(mesh),
+        nn=numpy.asarray(first_or_all(nns)),
+        fes_fn=numpy.asarray(first_or_all(fes_fns)),
     )

--- a/pysages/methods/metad.py
+++ b/pysages/methods/metad.py
@@ -9,7 +9,6 @@ both with optional support for grids.
 
 from typing import NamedTuple, Optional
 
-import numpy
 from jax import grad, jit
 from jax import numpy as np
 from jax import value_and_grad, vmap
@@ -19,6 +18,7 @@ from pysages.approxfun import compute_mesh
 from pysages.colvars import get_periods, wrap
 from pysages.grids import build_indexer
 from pysages.methods.core import GriddedSamplingMethod, Result, generalize
+from pysages.methods.utils import numpyfy_dictionary
 from pysages.utils import JaxArray, dispatch, gaussian, identity
 
 
@@ -366,4 +366,5 @@ def analyze(result: Result[Metadynamics]):
         heights.append(s.heights)
         metapotentials.append(build_metapotential(s.heights, s.centers, s.sigmas))
 
-    return dict(heights=numpy.asarray(heights), metapotential=numpy.asarray(metapotentials))
+    ana_result = dict(heights=heights, metapotential=metapotentials)
+    return numpyfy_dictionary(ana_result)

--- a/pysages/methods/metad.py
+++ b/pysages/methods/metad.py
@@ -18,7 +18,7 @@ from pysages.approxfun import compute_mesh
 from pysages.colvars import get_periods, wrap
 from pysages.grids import build_indexer
 from pysages.methods.core import GriddedSamplingMethod, Result, generalize
-from pysages.methods.utils import numpyfy_dictionary
+from pysages.methods.utils import numpyfy_vals
 from pysages.utils import JaxArray, dispatch, gaussian, identity
 
 
@@ -367,4 +367,4 @@ def analyze(result: Result[Metadynamics]):
         metapotentials.append(build_metapotential(s.heights, s.centers, s.sigmas))
 
     ana_result = dict(heights=heights, metapotential=metapotentials)
-    return numpyfy_dictionary(ana_result)
+    return numpyfy_vals(ana_result)

--- a/pysages/methods/metad.py
+++ b/pysages/methods/metad.py
@@ -9,6 +9,7 @@ both with optional support for grids.
 
 from typing import NamedTuple, Optional
 
+import numpy
 from jax import grad, jit
 from jax import numpy as np
 from jax import value_and_grad, vmap
@@ -365,4 +366,4 @@ def analyze(result: Result[Metadynamics]):
         heights.append(s.heights)
         metapotentials.append(build_metapotential(s.heights, s.centers, s.sigmas))
 
-    return dict(heights=heights, metapotential=metapotentials)
+    return dict(heights=numpy.asarray(heights), metapotential=numpy.asarray(metapotentials))

--- a/pysages/methods/spectral_abf.py
+++ b/pysages/methods/spectral_abf.py
@@ -32,7 +32,7 @@ from pysages.approxfun import (
 from pysages.grids import Chebyshev, Grid, build_indexer, convert
 from pysages.methods.core import GriddedSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
-from pysages.methods.utils import numpyfy_dictionary
+from pysages.methods.utils import numpyfy_vals
 from pysages.utils import Bool, Int, JaxArray, dispatch
 
 
@@ -333,4 +333,4 @@ def analyze(result: Result[SpectralABF]):
         fun=first_or_all(funs),
         fes_fn=first_or_all(fes_fns),
     )
-    return numpyfy_dictionary(ana_result)
+    return numpyfy_vals(ana_result)

--- a/pysages/methods/spectral_abf.py
+++ b/pysages/methods/spectral_abf.py
@@ -16,6 +16,7 @@ provided by the basis functions expansion.
 
 from typing import NamedTuple, Tuple
 
+import numpy
 from jax import jit
 from jax import numpy as np
 from jax.lax import cond
@@ -325,10 +326,10 @@ def analyze(result: Result[SpectralABF]):
         fes_fns.append(fes_fn)
 
     return dict(
-        histogram=first_or_all(hists),
-        mean_force=first_or_all(mean_forces),
-        free_energy=first_or_all(free_energies),
-        mesh=mesh,
-        fun=first_or_all(funs),
-        fes_fn=first_or_all(fes_fns),
+        histogram=numpy.asarray(first_or_all(hists)),
+        mean_force=numpy.asarray(first_or_all(mean_forces)),
+        free_energy=numpy.asarray(first_or_all(free_energies)),
+        mesh=numpy.asarray(mesh),
+        fun=numpy.asarray(first_or_all(funs)),
+        fes_fn=numpy.asarray(first_or_all(fes_fns)),
     )

--- a/pysages/methods/spectral_abf.py
+++ b/pysages/methods/spectral_abf.py
@@ -16,7 +16,6 @@ provided by the basis functions expansion.
 
 from typing import NamedTuple, Tuple
 
-import numpy
 from jax import jit
 from jax import numpy as np
 from jax.lax import cond
@@ -33,6 +32,7 @@ from pysages.approxfun import (
 from pysages.grids import Chebyshev, Grid, build_indexer, convert
 from pysages.methods.core import GriddedSamplingMethod, Result, generalize
 from pysages.methods.restraints import apply_restraints
+from pysages.methods.utils import numpyfy_dictionary
 from pysages.utils import Bool, Int, JaxArray, dispatch
 
 
@@ -325,11 +325,12 @@ def analyze(result: Result[SpectralABF]):
         funs.append(s.fun)
         fes_fns.append(fes_fn)
 
-    return dict(
-        histogram=numpy.asarray(first_or_all(hists)),
-        mean_force=numpy.asarray(first_or_all(mean_forces)),
-        free_energy=numpy.asarray(first_or_all(free_energies)),
-        mesh=numpy.asarray(mesh),
-        fun=numpy.asarray(first_or_all(funs)),
-        fes_fn=numpy.asarray(first_or_all(fes_fns)),
+    ana_result = dict(
+        histogram=first_or_all(hists),
+        mean_force=first_or_all(mean_forces),
+        free_energy=first_or_all(free_energies),
+        mesh=mesh,
+        fun=first_or_all(funs),
+        fes_fn=first_or_all(fes_fns),
     )
+    return numpyfy_dictionary(ana_result)

--- a/pysages/methods/spline_string.py
+++ b/pysages/methods/spline_string.py
@@ -283,7 +283,7 @@ def analyze(result: Result[SplineString]):
 
     umbrella_result = Result(result.method.umbrella_sampler, result.states, result.callbacks)
     ana = pysages.analyze(umbrella_result)
-    ana["path_history"] = result.method.path_history
+    ana["path_history"] = np.asarray(result.method.path_history)
     path = []
     point_convergence = []
     for i in range(len(result.method.path_history[-1])):

--- a/pysages/methods/spline_string.py
+++ b/pysages/methods/spline_string.py
@@ -24,7 +24,7 @@ from scipy.interpolate import interp1d
 import pysages
 from pysages.methods.core import Result, SamplingMethod
 from pysages.methods.umbrella_integration import UmbrellaIntegration
-from pysages.methods.utils import SerialExecutor, listify, numpyfy_dictionary
+from pysages.methods.utils import SerialExecutor, listify, numpyfy_vals
 from pysages.utils import dispatch
 
 
@@ -294,4 +294,4 @@ def analyze(result: Result[SplineString]):
     ana["point_convergence"] = point_convergence
     ana["path"] = path
 
-    return numpyfy_dictionary(ana)
+    return numpyfy_vals(ana)

--- a/pysages/methods/spline_string.py
+++ b/pysages/methods/spline_string.py
@@ -24,7 +24,7 @@ from scipy.interpolate import interp1d
 import pysages
 from pysages.methods.core import Result, SamplingMethod
 from pysages.methods.umbrella_integration import UmbrellaIntegration
-from pysages.methods.utils import SerialExecutor, listify
+from pysages.methods.utils import SerialExecutor, listify, numpyfy_dictionary
 from pysages.utils import dispatch
 
 
@@ -283,7 +283,7 @@ def analyze(result: Result[SplineString]):
 
     umbrella_result = Result(result.method.umbrella_sampler, result.states, result.callbacks)
     ana = pysages.analyze(umbrella_result)
-    ana["path_history"] = np.asarray(result.method.path_history)
+    ana["path_history"] = result.method.path_history
     path = []
     point_convergence = []
     for i in range(len(result.method.path_history[-1])):
@@ -291,7 +291,7 @@ def analyze(result: Result[SplineString]):
         b = result.method.path_history[-1][i]
         point_convergence.append(result.method.metric(a, b))
         path.append(a)
-    ana["point_convergence"] = np.asarray(point_convergence)
-    ana["path"] = np.asarray(path)
+    ana["point_convergence"] = point_convergence
+    ana["path"] = path
 
-    return ana
+    return numpyfy_dictionary(ana)

--- a/pysages/methods/umbrella_integration.py
+++ b/pysages/methods/umbrella_integration.py
@@ -217,10 +217,13 @@ def analyze(result: Result[UmbrellaIntegration]):
         if i > 0:
             free_energy.append(integrate(free_energy, mean_forces, centers, i))
 
+    for callback in result.callbacks:
+        callback.numpyfy()
+
     ana_result = dict(
         ksprings=ksprings,
         centers=centers,
-        histograms_data=result.callbacks.data,
+        histograms_data=result.callbacks,
         histogram_means=hist_means,
         mean_forces=mean_forces,
         free_energy=free_energy,

--- a/pysages/methods/umbrella_integration.py
+++ b/pysages/methods/umbrella_integration.py
@@ -21,12 +21,7 @@ import plum
 
 from pysages.methods.core import Result, SamplingMethod, _run
 from pysages.methods.harmonic_bias import HarmonicBias
-from pysages.methods.utils import (
-    HistogramLogger,
-    SerialExecutor,
-    listify,
-    numpyfy_dictionary,
-)
+from pysages.methods.utils import HistogramLogger, SerialExecutor, listify, numpyfy_vals
 from pysages.utils import dispatch
 
 
@@ -228,4 +223,4 @@ def analyze(result: Result[UmbrellaIntegration]):
         mean_forces=mean_forces,
         free_energy=free_energy,
     )
-    return numpyfy_dictionary(ana_result)
+    return numpyfy_vals(ana_result)

--- a/pysages/methods/umbrella_integration.py
+++ b/pysages/methods/umbrella_integration.py
@@ -223,7 +223,7 @@ def analyze(result: Result[UmbrellaIntegration]):
     ana_result = dict(
         ksprings=ksprings,
         centers=centers,
-        histograms_data=result.callbacks,
+        histograms=result.callbacks,
         histogram_means=hist_means,
         mean_forces=mean_forces,
         free_energy=free_energy,

--- a/pysages/methods/umbrella_integration.py
+++ b/pysages/methods/umbrella_integration.py
@@ -17,12 +17,16 @@ However, the method is not very accurate and it is preferred that more advanced 
 from copy import deepcopy
 from typing import Callable, Optional, Union
 
-import numpy
 import plum
 
 from pysages.methods.core import Result, SamplingMethod, _run
 from pysages.methods.harmonic_bias import HarmonicBias
-from pysages.methods.utils import HistogramLogger, SerialExecutor, listify
+from pysages.methods.utils import (
+    HistogramLogger,
+    SerialExecutor,
+    listify,
+    numpyfy_dictionary,
+)
 from pysages.utils import dispatch
 
 
@@ -213,11 +217,12 @@ def analyze(result: Result[UmbrellaIntegration]):
         if i > 0:
             free_energy.append(integrate(free_energy, mean_forces, centers, i))
 
-    return dict(
-        ksprings=numpy.asarray(ksprings),
-        centers=numpy.asarray(centers),
-        histograms=numpy.asarray(result.callbacks.data),
-        histogram_means=numpy.asarray(hist_means),
-        mean_forces=numpy.asarray(mean_forces),
-        free_energy=numpy.asarray(free_energy),
+    ana_result = dict(
+        ksprings=ksprings,
+        centers=centers,
+        histograms_data=result.callbacks.data,
+        histogram_means=hist_means,
+        mean_forces=mean_forces,
+        free_energy=free_energy,
     )
+    return numpyfy_dictionary(ana_result)

--- a/pysages/methods/umbrella_integration.py
+++ b/pysages/methods/umbrella_integration.py
@@ -17,6 +17,7 @@ However, the method is not very accurate and it is preferred that more advanced 
 from copy import deepcopy
 from typing import Callable, Optional, Union
 
+import numpy
 import plum
 
 from pysages.methods.core import Result, SamplingMethod, _run
@@ -213,10 +214,10 @@ def analyze(result: Result[UmbrellaIntegration]):
             free_energy.append(integrate(free_energy, mean_forces, centers, i))
 
     return dict(
-        ksprings=ksprings,
-        centers=centers,
-        histograms=result.callbacks,
-        histogram_means=hist_means,
-        mean_forces=mean_forces,
-        free_energy=free_energy,
+        ksprings=numpy.asarray(ksprings),
+        centers=numpy.asarray(centers),
+        histograms=numpy.asarray(result.callbacks.data),
+        histogram_means=numpy.asarray(hist_means),
+        mean_forces=numpy.asarray(mean_forces),
+        free_energy=numpy.asarray(free_energy),
     )

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -87,10 +87,10 @@ class HistogramLogger:
         self.counter += 1
         if self.counter > self.offset and self.counter % self.period == 0:
             if self.data is None:
-                self.data = copy.copy(state.xi[0]).reshape((1,) + state.xi[0].shape)
+                self.data = copy.copy(state.xi[0].reshape((1,)) + state.xi[0].shape)
             else:
                 self.data = np.concatenate(
-                    (self.data, state.xi[0]).reshape((1,) + state.xi[0].shape)
+                    (self.data, state.xi[0].reshape((1,)) + state.xi[0].shape)
                 )
 
     def get_histograms(self, **kwargs):

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -87,10 +87,10 @@ class HistogramLogger:
         self.counter += 1
         if self.counter > self.offset and self.counter % self.period == 0:
             if self.data is None:
-                self.data = copy.copy(state.xi[0].reshape((1,)) + state.xi[0].shape)
+                self.data = copy.copy(state.xi[0].reshape((1,) + state.xi[0].shape))
             else:
                 self.data = np.concatenate(
-                    (self.data, state.xi[0].reshape((1,)) + state.xi[0].shape)
+                    (self.data, state.xi[0].reshape((1,) + state.xi[0].shape))
                 )
 
     def get_histograms(self, **kwargs):

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -215,3 +215,4 @@ def numpyfy_vals(dictionary: dict, arrays_only: bool = False):
     for key, val in dictionary.items():
         if isarray(val):
             new_dict[key] = numpy.asarray(val)
+    return new_dict

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -86,12 +86,11 @@ class HistogramLogger:
         """
         self.counter += 1
         if self.counter > self.offset and self.counter % self.period == 0:
+            xi = state.xi[0]
             if self.data is None:
-                self.data = copy.copy(state.xi[0].reshape((1,) + state.xi[0].shape))
+                self.data = copy.copy(xi)
             else:
-                self.data = np.concatenate(
-                    (self.data, state.xi[0].reshape((1,) + state.xi[0].shape))
-                )
+                self.data = np.vstack((self.data, xi))
 
     def get_histograms(self, **kwargs):
         """

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -121,7 +121,7 @@ class HistogramLogger:
         Reset internal state.
         """
         self.counter = 0
-        self.data = []
+        self.data = None
 
     def numpyfy(self):
         self.data = numpy.asarray(self.data)

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -89,7 +89,9 @@ class HistogramLogger:
             if self.data is None:
                 self.data = copy.copy(state.xi[0]).reshape((1,) + state.xi[0].shape)
             else:
-                self.data = np.concatenate((self.data, state.xi[0]))
+                self.data = np.concatenate(
+                    (self.data, state.xi[0]).reshape((1,) + state.xi[0].shape)
+                )
 
     def get_histograms(self, **kwargs):
         """

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -188,6 +188,18 @@ def listify(arg, replicas, name, dtype):
 
 
 def isarray(val):
+    if (
+        isinstance(val, (list, tuple))
+        and len(val) > 0
+        and isinstance(val[0], (JaxArray, numpy.ndarray))
+    ):
+        shape = val[0].shape
+        for element in val:
+            if not isinstance(val, (JaxArray, numpy.ndarray)):
+                return False
+            if shape != element.shape:
+                return False
+        return True
     return isinstance(val, (JaxArray, numpy.ndarray))
 
 
@@ -197,7 +209,7 @@ def numpyfy_vals(dictionary: dict, arrays_only: bool = False):
     We recommend to pickle final analyzed results are numpyfying
     with `numpy_only=True` to avoid pickling issues.
 
-    JaxArrays and numpy arrays are converted to numpy arrays
+    JaxArrays, numpy arrays, and lists of numpy arrays are converted to numpy arrays
 
     Parameters
     ----------

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -10,6 +10,7 @@ This includes callback functor objects (callable classes).
 
 from concurrent.futures import Executor, Future
 
+import numpy
 from jax import numpy as np
 from plum import Dispatcher
 
@@ -174,3 +175,31 @@ def listify(arg, replicas, name, dtype):
         return arg
 
     return [dtype(arg) for i in range(replicas)]
+
+
+def numpyfy_dictionary(dictionary: dict):
+    """
+    Iterate all keys of the dictionary and convert every possible value into a numpy array.
+
+    Strings and numpy arrays, that would result in dtype=object are not converted.
+
+    Parameters
+    ----------
+
+    dictionary: dict
+        Input dictionary, which keys are attempted to be converted to numpy arrays.
+
+    Returns
+    -------
+
+    dict: The same dictionary, but keys are preferrably numpy arrays.
+    """
+
+    new_dict = {}
+    for key in dictionary:
+        new_dict[key] = dictionary[key]
+        if isinstance(dictionary[key], str):
+            numpy_array = numpy.asarray(dictionary[key])
+            if numpy_array.dtype != numpy.dtype("O"):
+                new_dict[key] = numpy_array
+    return new_dict

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -8,6 +8,7 @@ Collection of helpful classes for methods.
 This includes callback functor objects (callable classes).
 """
 
+import copy
 from concurrent.futures import Executor, Future
 
 import numpy
@@ -77,7 +78,7 @@ class HistogramLogger:
         self.period = period
         self.counter = 0
         self.offset = offset
-        self.data = []
+        self.data = None
 
     def __call__(self, snapshot, state, timestep):
         """
@@ -85,7 +86,10 @@ class HistogramLogger:
         """
         self.counter += 1
         if self.counter > self.offset and self.counter % self.period == 0:
-            self.data = np.concatenate((self.data, state.xi[0]))
+            if self.data is None:
+                self.data = copy.copy(state.xi[0]).reshape((1,) + state.xi[0].shape)
+            else:
+                self.data = np.concatenate((self.data, state.xi[0]))
 
     def get_histograms(self, **kwargs):
         """

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -181,7 +181,7 @@ def numpyfy_dictionary(dictionary: dict):
     """
     Iterate all keys of the dictionary and convert every possible value into a numpy array.
 
-    Strings and numpy arrays, that would result in dtype=object are not converted.
+    Strings and numpy arrays, that would result in `dtype == object` are not converted.
 
     Parameters
     ----------
@@ -192,7 +192,7 @@ def numpyfy_dictionary(dictionary: dict):
     Returns
     -------
 
-    dict: The same dictionary, but keys are preferrably numpy arrays.
+    dict: The same dictionary, but keys are preferably numpy arrays.
     """
 
     new_dict = {}

--- a/pysages/methods/utils.py
+++ b/pysages/methods/utils.py
@@ -15,8 +15,6 @@ import numpy
 from jax import numpy as np
 from plum import Dispatcher
 
-from pysages.utils import JaxArray
-
 # We use this to dispatch on the different `run` implementations
 # for `SamplingMethod`s.
 methods_dispatch = Dispatcher()


### PR DESCRIPTION
For the final result, we should prefer using normal numpy arrays instead of JAXarrays.
This should help a lot with pickling the final results.
JAX arrays can be a bit tricky to reconstruct in envs, that are not the same as the simulations were run.

So moving to numpy arrays, should enable user to pickle final results on the cluster and do the analysis (like plotting) on a local machine.
