### PR TITLE
Update trunk merge checks to match the gh workflows

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -66,9 +66,9 @@ lint:
 merge:
   required_statuses:
     - trunk
-    - test (ubuntu-20.04, 3.7)
+    - test (ubuntu-20.04, 3.8)
     - test (ubuntu-20.04, 3.9)
-    - test (macos-latest, 3.7)
+    - test (macos-latest, 3.8)
     - test (macos-latest, 3.9)
     - doc-test
     - forward-flux-sampling


### PR DESCRIPTION
For #242 we had to bump the GH workflow files to test on python 3.8 instead of 3.7, but trunk merge requirements were not updated accordingly.