### PR TITLE
More fixes for the Google Collab notebooks

### DIFF
--- a/examples/Advanced_Sampling_Introduction.ipynb
+++ b/examples/Advanced_Sampling_Introduction.ipynb
@@ -151,9 +151,7 @@
     "\n",
     "rm -rf PySAGES\n",
     "git clone https://github.com/SSAGESLabs/PySAGES.git &> /dev/null\n",
-    "#git clone https://github.com/pabloferz/PySAGES.git\n",
     "cd PySAGES\n",
-    "#git checkout non-group-cvs\n",
     "pip install -q . &> /dev/null"
    ]
   },
@@ -1457,7 +1455,7 @@
    ],
    "source": [
     "from pysages.methods import UmbrellaIntegration\n",
-    "method = UmbrellaIntegration(cvs, ksprings=kspring, centers=centers, hist_periods=100)\n",
+    "method = UmbrellaIntegration(cvs, kspring, centers, 100)\n",
     "result = pysages.run(method, generate_context, int(1e5))"
    ]
   },

--- a/examples/Advanced_Sampling_Introduction.md
+++ b/examples/Advanced_Sampling_Introduction.md
@@ -90,9 +90,7 @@ Now we can finally install PySAGES. We clone the newest version from [here](http
 
 rm -rf PySAGES
 git clone https://github.com/SSAGESLabs/PySAGES.git &> /dev/null
-#git clone https://github.com/pabloferz/PySAGES.git
 cd PySAGES
-#git checkout non-group-cvs
 pip install -q . &> /dev/null
 ```
 
@@ -720,7 +718,7 @@ $$\int \text{d} \xi p_i^b(\xi) p_{i+1}^b(\xi) \gg 0$$
 
 ```python colab={"base_uri": "https://localhost:8080/"} id="CtaNDUQ0SrTZ" outputId="3255e692-bfbd-4f97-cc21-8659aa2b5b37"
 from pysages.methods import UmbrellaIntegration
-method = UmbrellaIntegration(cvs, ksprings=kspring, centers=centers, hist_periods=100)
+method = UmbrellaIntegration(cvs, kspring, centers, 100)
 result = pysages.run(method, generate_context, int(1e5))
 ```
 

--- a/examples/hoomd-blue/umbrella_integration/Umbrella_Integration.ipynb
+++ b/examples/hoomd-blue/umbrella_integration/Umbrella_Integration.ipynb
@@ -367,7 +367,7 @@
     "    hoomd.context.initialize(\"\")\n",
     "    context = hoomd.context.SimulationContext()\n",
     "    with context:\n",
-    "        print(f\"Operating replica {kwargs.get(\"replica_num\")}\")\n",
+    "        print(f\"Operating replica {kwargs.get('replica_num')}\")\n",
     "        system = hoomd.init.read_gsd(\"start.gsd\")\n",
     "\n",
     "        hoomd.md.integrate.nve(group=hoomd.group.all())\n",

--- a/examples/hoomd-blue/umbrella_integration/Umbrella_Integration.md
+++ b/examples/hoomd-blue/umbrella_integration/Umbrella_Integration.md
@@ -190,7 +190,7 @@ def generate_context(**kwargs):
     hoomd.context.initialize("")
     context = hoomd.context.SimulationContext()
     with context:
-        print(f"Operating replica {kwargs.get("replica_num")}")
+        print(f"Operating replica {kwargs.get('replica_num')}")
         system = hoomd.init.read_gsd("start.gsd")
 
         hoomd.md.integrate.nve(group=hoomd.group.all())


### PR DESCRIPTION
Curiously, there is a problem with the `plum.dispatch` of constructors.
If I specify arguments with keywords, a constructor is called that doesn't match any on the ones specified and I get basically an empty `UmbrellaIntegration` instance.
That is weird, and potentially problematic. But I don't know how to fix it.

Not using keywords in this case fixed the problem.