### PR TITLE
Restrict plum to <2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ license = MIT/GPL-3.0
 [options]
 packages = find:
 python_requires = >=3.6
-install_requires = jax>=0.3.5; cython; plum-dispatch>=1.5.4; numba
+install_requires = jax>=0.3.5; cython; plum-dispatch>=1.5.4,<2; numba
 
 [build_sphinx]
 all-files = 1


### PR DESCRIPTION
Stopgap solution before #257 can be merged. This should allow people to use pysages while we sort out the issues with supporting plum 2.