### PR TITLE
Fix compatibility issue with `plum >= 2.2.1`

### DIFF
--- a/pysages/utils/compat.py
+++ b/pysages/utils/compat.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: MIT
 # See LICENSE.md and CONTRIBUTORS.md at https://github.com/SSAGESLabs/PySAGES
 
-import typing
-
 from importlib import import_module
 
 from jax.scipy import linalg
@@ -66,30 +64,12 @@ if _plum_version_tuple < (2, 0, 0):
 
     is_generic_subclass = issubclass
 
-elif _plum_version_tuple < (2, 2, 1):
-    _bt = import_module("beartype.door")
-    _pm = import_module("plum")
-
-    def dispatch_table(dispatch):
-        return dispatch.functions
-
-    def has_method(fn, T, index):
-        types_at_index = set()
-        for sig in fn.methods:
-            typ = sig.types[index]
-            if _pm.get_origin(typ) is _pm.Union:
-                types_at_index.update(_pm.get_args(typ))
-            else:
-                types_at_index.add(typ)
-        return T in types_at_index
-
-    def is_generic_subclass(A, B):
-        return _bt.TypeHint(A) <= _bt.TypeHint(B)
-
 else:
-    # Compatibility for plum >= 2.2.1
-    # https://github.com/beartype/plum/pull/94
     _bt = import_module("beartype.door")
+    if _plum_version_tuple < (2, 2, 1):
+        _typing = import_module("plum")
+    else:
+        _typing = import_module("typing")
 
     def dispatch_table(dispatch):
         return dispatch.functions
@@ -98,8 +78,8 @@ else:
         types_at_index = set()
         for sig in fn.methods:
             typ = sig.types[index]
-            if typing.get_origin(typ) is typing.Union:
-                types_at_index.update(typing.get_args(typ))
+            if _typing.get_origin(typ) is _typing.Union:
+                types_at_index.update(_typing.get_args(typ))
             else:
                 types_at_index.add(typ)
         return T in types_at_index

--- a/pysages/utils/compat.py
+++ b/pysages/utils/compat.py
@@ -66,10 +66,7 @@ if _plum_version_tuple < (2, 0, 0):
 
 else:
     _bt = import_module("beartype.door")
-    if _plum_version_tuple < (2, 2, 1):
-        _typing = import_module("plum")
-    else:
-        _typing = import_module("typing")
+    _typing = import_module("plum" if _plum_version_tuple < (2, 2, 1) else "typing")
 
     def dispatch_table(dispatch):
         return dispatch.functions

--- a/pysages/utils/compat.py
+++ b/pysages/utils/compat.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # See LICENSE.md and CONTRIBUTORS.md at https://github.com/SSAGESLabs/PySAGES
 
+import typing
+
 from importlib import import_module
 
 from jax.scipy import linalg
@@ -64,7 +66,7 @@ if _plum_version_tuple < (2, 0, 0):
 
     is_generic_subclass = issubclass
 
-else:
+elif _plum_version_tuple < (2, 2, 1):
     _bt = import_module("beartype.door")
     _pm = import_module("plum")
 
@@ -77,6 +79,27 @@ else:
             typ = sig.types[index]
             if _pm.get_origin(typ) is _pm.Union:
                 types_at_index.update(_pm.get_args(typ))
+            else:
+                types_at_index.add(typ)
+        return T in types_at_index
+
+    def is_generic_subclass(A, B):
+        return _bt.TypeHint(A) <= _bt.TypeHint(B)
+
+else:
+    # Compatibility for plum >= 2.2.1
+    # https://github.com/beartype/plum/pull/94
+    _bt = import_module("beartype.door")
+
+    def dispatch_table(dispatch):
+        return dispatch.functions
+
+    def has_method(fn, T, index):
+        types_at_index = set()
+        for sig in fn.methods:
+            typ = sig.types[index]
+            if typing.get_origin(typ) is typing.Union:
+                types_at_index.update(typing.get_args(typ))
             else:
                 types_at_index.add(typ)
         return T in types_at_index


### PR DESCRIPTION
This pr aims to fix the compatibility issue caused by `pysages/utils/compat.py`. During recent release 2.2.1, `plum` has dropped its support to Python 3.7, and removed functions and classes that were used as a workaround. As a result, I made edits to the scripts such that it will resort to Python's built-in `typing` module for `get_args()`, `get_origin()` and `Union`. These functions are introduced in Python 3.8, which is an install requirement of the latest `plum` module.