### PR TITLE
Miscellaneous fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@ Make sure you have [GNU make](https://www.gpu.org/software/make/) installed.
 You can build the documentation from you local copy of the PySAGES repository as follows:
 
 ```shell
-pip install -r docs/requirements.txt
+cd docs
+pip install -r requirements.txt
 make html
 ```
 

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,6 +1,0 @@
-{% extends "!layout.html" %} {% block extrahead %}
-<link
-  rel="stylesheet"
-  href="https://fonts.googleapis.com/css?family=Atkinson Hyperlegible|Montserrat"
-/>
-{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,6 +100,7 @@ html_theme_options = {
 # # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 html_css_files = [
+    "https://fonts.googleapis.com/css?family=Atkinson Hyperlegible|Montserrat",
     "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/fontawesome.min.css",
     "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/solid.min.css",
     "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/brands.min.css",

--- a/pysages/backends/hoomd.py
+++ b/pysages/backends/hoomd.py
@@ -20,7 +20,7 @@ from hoomd.dlext import (
 )
 from jax import jit
 from jax import numpy as np
-from jax.dlpack import from_dlpack as asarray
+from jax.dlpack import from_dlpack
 
 from pysages.backends.core import SamplingContext
 from pysages.backends.snapshot import (
@@ -125,11 +125,11 @@ class Sampler(SamplerBase):
 
     def _pack_snapshot(self, positions, vel_mass, forces, rtags, images):
         return Snapshot(
-            asarray(positions),
-            asarray(vel_mass),
-            asarray(forces),
-            asarray(rtags),
-            asarray(images),
+            from_dlpack(positions),
+            from_dlpack(vel_mass),
+            from_dlpack(forces),
+            from_dlpack(rtags),
+            from_dlpack(images),
             self.box,
             self.dt,
         )
@@ -149,11 +149,11 @@ else:
 def take_snapshot(sampling_context, location=default_location()):
     context = sampling_context.context
     sysview = sampling_context.view
-    positions = copy(asarray(positions_types(sysview, location, AccessMode.Read)))
-    vel_mass = copy(asarray(velocities_masses(sysview, location, AccessMode.Read)))
-    forces = copy(asarray(net_forces(sysview, location, AccessMode.ReadWrite)))
-    ids = copy(asarray(rtags(sysview, location, AccessMode.Read)))
-    imgs = copy(asarray(images(sysview, location, AccessMode.Read)))
+    positions = copy(from_dlpack(positions_types(sysview, location, AccessMode.Read)))
+    vel_mass = copy(from_dlpack(velocities_masses(sysview, location, AccessMode.Read)))
+    forces = copy(from_dlpack(net_forces(sysview, location, AccessMode.ReadWrite)))
+    ids = copy(from_dlpack(rtags(sysview, location, AccessMode.Read)))
+    imgs = copy(from_dlpack(images(sysview, location, AccessMode.Read)))
 
     check_device_array(positions)  # currently, we only support `DeviceArray`s
 
@@ -200,17 +200,14 @@ def build_snapshot_methods(sampling_method):
 
 
 def build_helpers(context, sampling_method):
+    utils = importlib.import_module(".utils", package="pysages.backends")
+
     # Depending on the device being used we need to use either cupy or numpy
     # (or numba) to generate a view of jax's DeviceArrays
     if is_on_gpu(context):
-        cupy = importlib.import_module("cupy")
-        view = cupy.asarray
-
-        def sync_forces():
-            cupy.cuda.get_current_stream().synchronize()
+        sync_forces, view = utils.cupy_helpers()
 
     else:
-        utils = importlib.import_module(".utils", package="pysages.backends")
         view = utils.view
 
         def sync_forces():

--- a/pysages/backends/hoomd.py
+++ b/pysages/backends/hoomd.py
@@ -61,11 +61,15 @@ if getattr(hoomd, "__version__", "").startswith("2."):
         context.integrator.cpp_integrator.removeHalfStepHook()
 
 else:
+    if hasattr(hoomd.dlext, "__version__"):
+        SamplerBase = DLExtSampler
 
-    class SamplerBase(DLExtSampler, md.HalfStepHook):
-        def __init__(self, sysview, update, location, mode):
-            md.HalfStepHook.__init__(self)
-            DLExtSampler.__init__(self, sysview, update, location, mode)
+    else:
+
+        class SamplerBase(DLExtSampler, md.HalfStepHook):
+            def __init__(self, sysview, update, location, mode):
+                md.HalfStepHook.__init__(self)
+                DLExtSampler.__init__(self, sysview, update, location, mode)
 
     def is_on_gpu(context):
         return not isinstance(context.device, hoomd.device.CPU)

--- a/pysages/backends/utils.py
+++ b/pysages/backends/utils.py
@@ -2,6 +2,7 @@
 # See LICENSE.md and CONTRIBUTORS.md at https://github.com/SSAGESLabs/PySAGES
 
 import ctypes
+import importlib
 
 import numba
 import numpy
@@ -9,6 +10,26 @@ from numpy.ctypeslib import as_ctypes_type
 
 from pysages.typing import JaxArray
 from pysages.utils import dispatch
+
+
+def cupy_helpers():
+    """Returns two methods:
+
+    `sync` -- for synchronizing the current CUDA stream
+    `view` -- to wrap a `JaxArray` as a `cupy.ndarray`
+    """
+    cupy = importlib.import_module("cupy")
+    dlpack = importlib.import_module("jax.dlpack")
+
+    def _sync():
+        """Synchronizes the current cupy's CUDA stream."""
+        cupy.cuda.get_current_stream().synchronize()
+
+    def _view(x: JaxArray):
+        """Wraps a view of `x: JaxArray` as a `cupy.ndarray`."""
+        return cupy.from_dlpack(dlpack.to_dlpack(x))
+
+    return _sync, _view
 
 
 @dispatch

--- a/pysages/utils/compat.py
+++ b/pysages/utils/compat.py
@@ -67,6 +67,7 @@ if _plum_version_tuple < (2, 0, 0):
 else:
     _bt = import_module("beartype.door")
     _typing = import_module("plum" if _plum_version_tuple < (2, 2, 1) else "typing")
+    _util = _typing.type if _plum_version_tuple < (2, 2, 1) else _typing
 
     def dispatch_table(dispatch):
         return dispatch.functions
@@ -75,8 +76,8 @@ else:
         types_at_index = set()
         for sig in fn.methods:
             typ = sig.types[index]
-            if _typing.get_origin(typ) is _typing.Union:
-                types_at_index.update(_typing.get_args(typ))
+            if _util.get_origin(typ) is _typing.Union:
+                types_at_index.update(_util.get_args(typ))
             else:
                 types_at_index.add(typ)
         return T in types_at_index


### PR DESCRIPTION
This PR addresses the following small but unrelated issues:

 - [x] Missed edge cases not handled by #280 (71b5fa47eb8f2344fb7e06b78d9ad1b106290f41).
 - [x] Some recent combination of changes on either or both CuPy and Jax makes `cupy.asarray(x)` for `x: JaxArray` return a copy instead of a view (134d0854a7da0cb3a44bbfbc867d29fded551ac4).
 - [x] Upcoming compatibility changes introduced by SSAGESLabs/hoomd-dlext/pull/23 (71991b5e81698ffd74b185c292d8ac6256d5d395).
 - [x] Some fonts were intended to be loaded by #281, but currently fail (e6533cde6ea4eb738682d0dc251e40de26dff406).