### PR TITLE
Neighbor list with JAX

### DIFF
--- a/pysages/nlist/CellList.py
+++ b/pysages/nlist/CellList.py
@@ -55,23 +55,6 @@ class CellList:
         self.buffer_size_cell = buffer_size_cell
         return None
     
-    def get_cell_ids(self, pos: jax.Array) -> jax.Array:
-        """
-        Get cell ids for each particle in pos matrix.
-
-        Args:
-            pos (jax.Array): Array of particle positions (N, 3)
-
-        Returns:
-            jax.Array: Array of cell ids for each particle (N, ). Also sets the cell_idx attribute.
-        """
-        self.cell_idx = np.zeros(pos.shape[0], dtype=np.int32)
-        self.cell_idx = _get_cell_ids(pos, self.cell_cut, self.cell_edge)
-        
-        if self.buffer_size_cell is None: # can be set manually if needed
-            self.buffer_size_cell = np.int32(np.ceil(pos.shape[0]//self.cell_num * 1.5)) # set the size of the nl list per cell to 50% larger than the average number of particles per cell
-        return self.cell_idx
-    
     def _get_neighbor_ids(self, idx: int) -> jax.Array:  
         """
         Get neighbor ids for a single particle.
@@ -170,6 +153,23 @@ class CellList:
 
         return n_ids
     
+    def initiate(self, pos: jax.Array) -> None:
+        """
+        Initialize the cell list.
+
+        Args:
+            pos (jax.Array): Array of particle positions (N, 3)
+
+        Returns:
+            None
+        """
+        if self.buffer_size_cell is None: # can be set manually if needed
+            self.buffer_size_cell = np.int32(np.ceil(pos.shape[0]//self.cell_num * 1.5)) # set the size of the nl list per cell to 50% larger than the average number of particles per cell
+        # get the cell ids
+        self.cell_idx = np.zeros(pos.shape[0], dtype=np.int32)
+        self.cell_idx = _get_cell_ids(pos, self.cell_cut, self.cell_edge)
+        return None
+    
     def update(self, pos: jax.Array) -> None:
         """
         Update the cell list.
@@ -180,6 +180,6 @@ class CellList:
         Returns:
             None
         """
-        # update the cell ids by calling get_cell_ids
-        self.get_cell_ids(pos)
+        # update the cell ids by calling _get_cell_ids
+        self.cell_idx = _get_cell_ids(pos, self.cell_cut, self.cell_edge)
         return None

--- a/pysages/nlist/CellList.py
+++ b/pysages/nlist/CellList.py
@@ -1,0 +1,185 @@
+from typing import Tuple
+
+
+import jax
+from jax import numpy as np
+from jax import lax
+from cellfuncs import _idx_to_tuple, _tuple_to_idx, _get_cell_ids, _get_neighbor
+
+class CellList:
+    """
+    Cell list neighbor list algorithm for 3D systems implemented in JAX.
+    Loosely based on https://aiichironakano.github.io/cs596/01-1LinkedListCell.pdf
+
+    Raises:
+        ValueError: If the cell list is not initialized before calling get_neighbor_ids()
+
+    Returns:
+        CellList: CellList object containing the following attributes:
+
+            box (Tuple): box size (3, )
+            cutoff (float): cutoff distance for neighbor list (scalar)
+            cell_edge (jax.Array): number of cells in each dimension (3, )
+            cell_cut (jax.Array): cell size in each dimension (3, )
+            cell_num (int): total number of cells (scalar)
+            cell_idx (jax.Array): cell index for each particle (N, )
+            buffer_size_cell (int): max number of neighbors per cell (scalar). If not set, it is set to 50% larger than the average number of particles per cell.
+    """
+    box: Tuple
+    cutoff: float
+    cell_edge: jax.Array
+    cell_cut: jax.Array
+    cell_num: int
+    cell_idx: jax.Array
+    buffer_size_box: int
+
+    def __init__(self, box: Tuple, cutoff: float, buffer_size_cell: int = None) -> None:
+        self.box = lax.stop_gradient(np.asarray(box)) # (3, )
+        self.cutoff = lax.stop_gradient(cutoff) # scalar
+        self.cell_edge = np.floor(self.box/self.cutoff) # (3, )
+        self.cell_cut = self.box/self.cell_edge # (3, )
+        self.cell_num = np.prod(self.cell_edge) # scalar
+        self.cell_idx = None # (N, )
+        self.buffer_size_cell = buffer_size_cell # scalar
+    
+    def set_buffer_size(self, buffer_size_cell: int) -> None:
+        """
+        Setter for buffer_size_cell attribute.
+
+        Args:
+            buffer_size_cell (int): max number of neighbors per cell
+
+        Returns:
+            None
+        """
+        self.buffer_size_cell = buffer_size_cell
+        return None
+    
+    def get_cell_ids(self, pos: jax.Array) -> jax.Array:
+        """
+        Get cell ids for each particle in pos matrix.
+
+        Args:
+            pos (jax.Array): Array of particle positions (N, 3)
+
+        Returns:
+            jax.Array: Array of cell ids for each particle (N, ). Also sets the cell_idx attribute.
+        """
+        self.cell_idx = np.zeros(pos.shape[0], dtype=np.int32)
+        self.cell_idx = _get_cell_ids(pos, self.cell_cut, self.cell_edge)
+        
+        if self.buffer_size_cell is None: # can be set manually if needed
+            self.buffer_size_cell = np.int32(np.ceil(pos.shape[0]//self.cell_num * 1.5)) # set the size of the nl list per cell to 50% larger than the average number of particles per cell
+        return self.cell_idx
+    
+    def _get_neighbor_ids(self, idx: int) -> jax.Array:  
+        """
+        Get neighbor ids for a single particle.
+
+        Args:
+            idx (int): index of the particle in the pos matrix (scalar)
+
+        Raises:
+            ValueError: If the neighbor list overflows
+        
+        Returns:
+            jax.Array: Array of neighbor ids for the particle (N, )
+        """
+        cell_id = self.cell_idx[idx] # index of the cell that the particle is in scalar
+        cell_id = np.expand_dims(cell_id, axis=0) # scalar to (1, )
+        
+        cell_tuple = _idx_to_tuple(cell_id, self.cell_edge) # tuple of the cell that the particle is in (1, dim)
+        
+        neighbor_tuples = []
+        for i in [-1, 0, 1]: # loop over cells behind and ahead of the current cell in each dimension
+            for j in [-1, 0, 1]: 
+                    for k in [-1, 0, 1]:
+                        neighbor_tuples.append(np.asarray([cell_tuple[0]+i, cell_tuple[1]+j, cell_tuple[2]+k]))
+        
+        neighbor_tuples = np.asarray(neighbor_tuples) # list to jax.Array (27, dim)
+        neighbor_tuples_wrapped = jax.vmap(_get_neighbor, in_axes=(0, None), out_axes=0)(neighbor_tuples, self.cell_edge) # wrap the cell ids of the neighbors (27, dim)
+        
+        # get scalar ids for the neighboring cells
+        neighbor_cell_ids = jax.vmap(_tuple_to_idx, (0, None))(neighbor_tuples_wrapped, self.cell_edge)
+        
+        neighbor_ids = [] # get ids of the particles in the neighboring cells. -1 is used as a filler for empty cells.
+        for cidx in neighbor_cell_ids:
+            neighbor_ids.append(np.where(self.cell_idx == cidx, fill_value=-1, size=self.buffer_size_cell)[0])
+
+            
+        # concatenate the neighbor ids into a single array.
+        neighbor_ids = np.concatenate(neighbor_ids, axis=-1)
+        return neighbor_ids
+    
+    def get_neighbor_ids(self, idxs: jax.Array, mask_self: bool= False) -> jax.Array:
+        """
+        Get neighbor ids for a list of particles. Uses vmap to vectorize the _get_neighbor_ids function.
+
+        Args:
+            idxs (jax.Array): Array of particle indices (n, )
+            mask_self (bool, optional): Whether to exclude self from neighbor list. Defaults to False.
+
+        Raises:
+            ValueError: If the cell list is not initialized before calling get_neighbor_ids()
+
+        Returns:
+            jax.Array: Array of neighbor ids for each particle (n, buffer_size_nl))
+        """
+        if self.cell_idx is None:
+            raise ValueError("Cell list is not initialized. Call get_cell_ids() first.")
+        
+        # convert idxs to jax.Array if it is not already
+        if not isinstance(idxs, np.ndarray):
+            idxs = np.asarray(idxs)
+        # expand dims if idxs is a single particle
+        if len(idxs.shape) == 0:
+            idxs = np.expand_dims(idxs, axis=-1)
+
+        if idxs.shape[0] == 1: # single particle case, no vmap
+            # get neighbor ids for the particle
+            n_ids = self._get_neighbor_ids(idxs[0])
+            # check for overflow
+            min_buffer = np.count_nonzero(n_ids == -1, axis=-1)
+            if min_buffer < 27: # if there are less than 27 -1s in a row of the neighbor list, there is an overflow from buffer_size_cell
+                raise ValueError("Neighbor list overflow. Increase buffer_size_cell.")
+            # remove self from neighbor list if mask_self is True
+            if mask_self:
+                n_ids = n_ids[n_ids != idxs[0]]
+            # sort 
+            n_ids = np.sort(n_ids)[::-1]
+            # truncate. Remove the -1s from the end of the neighbor list(smallest possible neighbor list).
+            n_ids = n_ids[:-min_buffer]
+            return n_ids
+        else:
+            # get neighbor ids for the particles
+            n_ids = jax.vmap(self._get_neighbor_ids)(idxs)
+            # check for overflow
+            min_buffer = np.min(np.count_nonzero(n_ids == -1, axis=-1))
+            if min_buffer < 27: # if there are less than 27 -1s in a row of the neighbor list, there is an overflow from buffer_size_cell
+                raise ValueError("Neighbor list overflow. Increase buffer_size_cell.")
+            # remove self from neighbor list if mask_self is True
+            if mask_self:
+                # set the self index to -1
+                n_ids = n_ids.at[..., n_ids == idxs[:, None]].set(-1)
+                # add one to the minimum buffer size to account for the -1 just added
+                min_buffer += 1
+            # sort
+            n_ids = np.sort(n_ids, axis=-1)[:, ::-1]
+            # truncate. Remove the -1s from the end of the neighbor list so that the row with the least -1s will have none (smallest possible neighbor list).
+            n_ids = n_ids[:, :-min_buffer]
+
+        return n_ids
+    
+    def update(self, pos: jax.Array) -> None:
+        """
+        Update the cell list.
+
+        Args:
+            pos (jax.Array): Array of particle positions (N, 3)
+
+        Returns:
+            None
+        """
+        # update the cell ids by calling get_cell_ids
+        self.get_cell_ids(pos)
+        return None

--- a/pysages/nlist/VerletList.py
+++ b/pysages/nlist/VerletList.py
@@ -1,0 +1,121 @@
+import jax
+import jax.numpy as np
+from jax import lax
+
+class VerletList:
+    """
+    Verlet list neighbor list algorithm for 3D systems implemented in JAX. Originally implemented to work with the CellList class as a hybrid neighbor list algorithm.
+
+    Returns:
+        VerletList: VerletList object containing the following attributes:
+
+            cutoff (float): cutoff distance for neighbor list (scalar)
+            buffer_size (int): max number of neighbors per cell (scalar)
+
+    """
+    cutoff: float
+    buffer_size: int
+
+    def __init__(self, cutoff: float) -> None:
+        self.cutoff = lax.stop_gradient(cutoff) # scalar
+        self.buffer_size = None # scalar
+    
+    def set_buffer_size(self, buffer_size: int) -> None:
+        """
+        Setter for buffer_size attribute.
+
+        Args:
+            buffer_size (int): max number of neighbors per cell
+
+        Returns:
+            None
+        """
+        self.buffer_size = buffer_size
+        return None
+
+    def _get_dist(self, i: jax.Array, j: jax.Array) -> np.float32:
+        """
+        Calculate the distance between two particles. (helper function for _pairwise_dist to use with vmap)
+
+        Args:
+            i (jax.Array): Position of particle i (3, )
+            j (jax.Array): Position of particle j (3, )
+
+        Returns:
+            np.float32: Distance between particles i and j (scalar)
+        """
+        return np.linalg.norm(i-j)
+
+    def _pairwise_dist(self, pos: jax.Array, ref: jax.Array) -> jax.Array:
+        """
+        Calculate the pairwise distance between particles in pos and a single reference particle. (helper function for get_neighbor_ids to use with vmap)
+
+        Args:
+            pos (jax.Array): position of particles (N, 3)
+            ref (jax.Array): position of reference particle (3, )
+
+        Returns:
+            jax.Array: array of distances between particles and reference particle (N, )
+        """
+        return jax.vmap(self._get_dist, (0, None))(pos, ref)
+
+    def _is_neighbor(self, dist: jax.Array) -> jax.Array:
+        """
+        Check if a particle is a neighbor of the reference particle. (helper function for get_neighbor_ids to use with vmap)
+
+        Args:
+            dist (jax.Array): Array of distances between particles and reference particle (N, )
+
+        Returns:
+            jax.Array: Array of bools indicating whether a particle is a neighbor of the reference particle (N, )
+        """
+        return dist < self.cutoff
+    
+    def get_neighbor_ids(self, pos: jax.Array, sparse: bool = False, mask_self: bool = False) -> jax.Array:
+        """
+        Get neighbor ids for each particle in pos matrix.
+
+        Args:
+            pos (jax.Array): Array of particle positions (N, 3)
+            sparse (bool, optional): Whether to return the full (N, N) matrix of neighborhood or an Array. Defaults to False.
+            mask_self (bool, optional): Whether to exclude self from neighbor list. Defaults to False.
+
+        Returns:
+            jax.Array: Array of neighbor ids for each particle (N, ) or (N, N) matrix of bools indicating whether a particle is a neighbor of another particle.
+        """
+        # if buffer_size is not set, set it to the number of particles
+        if self.buffer_size is None:
+            self.buffer_size = pos.shape[0]
+        # calculate the pairwise distances between all particles
+        pair_dists = jax.vmap(self._pairwise_dist, (None, 0))(pos, pos)
+        # check if a particle is a neighbor of another particle based on the cutoff distance
+        is_neighbor = jax.vmap(self._is_neighbor)(pair_dists)
+        # remove self from neighbor list if mask_self is True
+        if mask_self:
+            i, j = np.diag_indices(is_neighbor.shape[0])
+            is_neighbor = is_neighbor.at[..., i, j].set(False)
+        # return a list of arrays if sparse is True
+        if sparse: # return a list of arrays
+            neighbor_list = []
+            for row in is_neighbor:
+                neighbor_list.append(np.where(row)[0])
+            return neighbor_list
+        
+        return is_neighbor # return a NxN array of bools
+    
+    def get_neighborhood(self, pos: jax.Array, ref: jax.Array) -> jax.Array:
+        """
+        Get the neighborhood of a specific particle. Implemented to work with the CellList class as a hybrid neighbor list algorithm.
+
+        Args:
+            pos (jax.Array): Array of particle positions (N, 3)
+            ref (jax.Array): position of reference particle (3, )
+
+        Returns:
+            jax.Array: Array of bools indicating whether a particle is a neighbor of the reference particle (N, )
+        """
+        # calculate the pairwise distances between all particles and the reference particle
+        pair_dists = self._pairwise_dist(pos, ref)
+        # check if a particle is a neighbor of the reference particle based on the cutoff distance
+        is_neighbor = self._is_neighbor(pair_dists)
+        return is_neighbor

--- a/pysages/nlist/cellfuncs.py
+++ b/pysages/nlist/cellfuncs.py
@@ -1,0 +1,87 @@
+import jax
+from jax import jit
+import jax.numpy as np
+
+@jit
+def _idx_to_tuple(idx: int, cell_edge: jax.Array) -> jax.Array:
+    """
+    Convert cell index from scalar to tuple.
+
+    Args:
+        idx (int): Scalar index of cell
+        cell_edge (jax.Array): Number of cells in each dimension
+
+    Returns:
+        jax.Array: [index in x, index in y, index in z] (3,) or (N, 3)
+    """
+    x: np.int32 = idx//(cell_edge[1]*cell_edge[2])
+    y: np.int32 = (idx//cell_edge[2])%cell_edge[1]
+    z: np.int32 = idx%cell_edge[2]
+    return np.concatenate([x, y, z], axis=-1, dtype=np.int32)
+
+@jit
+def _tuple_to_idx(tup: jax.Array, cell_edge: jax.Array) -> np.int32 | jax.Array:
+    """
+    Covnert cell index from tuple to scalar.
+
+    Args:
+        tup (jax.Array): [index in x, index in y, index in z]
+        cell_edge (jax.Array): Number of cells in each dimension
+
+    Returns:
+        np.int32 or jax.Array: Scalar index of cell or (N, ) array of scalar indices
+    """
+    return np.int32(tup[...,0]*cell_edge[1]*cell_edge[2] + tup[...,1]*cell_edge[2] + tup[...,2])
+
+@jit
+def _get_cell_ids(pos: jax.Array, cell_cut: jax.Array, cell_edge: jax.Array) -> jax.Array:
+    """
+    Get scalar cell ids for each particle (row) in pos matrix.
+
+    Args:
+        pos (jax.Array): matrix of particle positions (N, 3)
+        cell_cut (jax.Array): Cut off distance for each cell
+        cell_edge (jax.Array): Number of cells in each dimension
+
+    Returns:
+        jax.Array: Array of cell ids for each particle (N, )
+    """
+    cell_tuples: np.int32 = pos//cell_cut
+    cell_ids = _tuple_to_idx(cell_tuples, cell_edge)
+    return cell_ids
+
+@jit
+def _wrap_cell_ids(cell_ids: jax.Array, cell_edge: np.int32) -> jax.Array:
+    """
+    Wraps the cell ids of particles in edge cells. (single dimension)
+
+    Args:
+        cell_ids (jax.Array): Array of tuple cell ids in the current dimension for each particle (N, 1)
+        cell_edge (np.int32): Number of cells in current dimension
+
+    Returns:
+        jax.Array: Wrapped cell ids (tuple) for each particle (N, 3)
+    """
+    out_of_bound_low = (cell_ids == -1) # if cell id is -1 (out of bound from below)
+    out_of_bound_high = (cell_ids == cell_edge) # if cell id equal to the number of cells in that dimension (out of bound from above)
+    cell_ids = np.where(out_of_bound_low, cell_edge-1, cell_ids) # if out of bound, then wrap around from below
+    cell_ids = np.where(out_of_bound_high, 0, cell_ids) # if out of bound, then wrap around from above
+    return cell_ids
+
+@jit
+def _get_neighbor(ids: jax.Array, cell_edge: jax.Array) -> jax.Array:
+    """
+    Wrap the tuple cell ids of particles for each neighbor. (helper function for _get_neighbor_ids to use with vmap)
+
+    Args:
+        ids (jax.Array): Array of tuple cell ids (N, 3)
+        cell_edge (jax.Array): Array of number of cells in each dimension (3, )
+
+    Returns:
+        jax.Array: Wrapped tuple cell ids (N, 3)
+    """
+    i, j, k = ids
+    x = _wrap_cell_ids(i, cell_edge[0])
+    y = _wrap_cell_ids(j, cell_edge[1])
+    z = _wrap_cell_ids(k, cell_edge[2])
+    return np.asarray([x, y, z])

--- a/pysages/nlist/testbench.ipynb
+++ b/pysages/nlist/testbench.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from CellList import CellList\n",
+    "from VerletList import VerletList\n",
+    "import jax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "box_size = 8\n",
+    "positions = jax.random.uniform(jax.random.PRNGKey(0), (int(1e3), 3))*box_size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_list = CellList(box = (box_size, box_size, box_size), cutoff = 2.0)\n",
+    "cell_list.get_cell_ids(positions)\n",
+    "idxs = jax.numpy.asarray(list(range(positions.shape[0])))\n",
+    "all_ns = cell_list.get_neighbor_ids(idxs, mask_self=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "verlet_list = VerletList(cutoff = 2.0)\n",
+    "atom0_n_ids = all_ns[0][all_ns[0] != -1]\n",
+    "neighbors = verlet_list.get_neighborhood(positions[atom0_n_ids, :], positions[0, :])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atom0_real_neighnors = atom0_n_ids[neighbors]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([993, 988, 968, 961, 959, 951, 947, 923, 891, 872, 871, 862, 828,\n",
+       "       808, 770, 736, 735, 708, 681, 631, 629, 621, 600, 594, 571, 555,\n",
+       "       541, 529, 509, 506, 466, 443, 437, 433, 400, 344, 328, 314, 309,\n",
+       "       283, 250, 242, 197, 145, 119,  98,  95,  47,  40,  22],      dtype=int32)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "atom0_real_neighnors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "jax",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pysages/nlist/testbench.ipynb
+++ b/pysages/nlist/testbench.ipynb
@@ -23,9 +23,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "I0000 00:00:1705619253.005336       1 tfrt_cpu_pjrt_client.cc:349] TfrtCpuClient created.\n"
+     ]
+    }
+   ],
    "source": [
     "box_size = 8\n",
     "positions = jax.random.uniform(jax.random.PRNGKey(0), (int(1e3), 3))*box_size"
@@ -38,7 +47,7 @@
    "outputs": [],
    "source": [
     "cell_list = CellList(box = (box_size, box_size, box_size), cutoff = 2.0)\n",
-    "cell_list.get_cell_ids(positions)\n",
+    "cell_list.initiate(positions)\n",
     "idxs = jax.numpy.asarray(list(range(positions.shape[0])))\n",
     "all_ns = cell_list.get_neighbor_ids(idxs, mask_self=True)"
    ]


### PR DESCRIPTION
This is a basic implementation of cell list and Verlet list methods for creating neighbor lists. It needs some work before it can be integrated into the main PySAGES workflow. There's a notebook `/pysages/nlist/testbench.ipynb` with a naive implementation of a hybrid Cell list/Verlet list method that should be easy to follow.