### PR TITLE
Fix incorrect ordering of the ase cell

### DIFF
--- a/pysages/backends/ase.py
+++ b/pysages/backends/ase.py
@@ -108,10 +108,7 @@ def take_snapshot(simulation, forces=None):
     masses = np.asarray(atoms.get_masses()).reshape(-1, 1)
     vel_mass = (momenta, masses)
 
-    a = atoms.cell[0]
-    b = atoms.cell[1]
-    c = atoms.cell[2]
-    H = ((a[0], a[1], a[2]), (b[0], b[1], b[2]), (c[0], c[1], c[2]))
+    H = (*atoms.cell,)
     origin = (0.0, 0.0, 0.0)
     dt = simulation.dt
 

--- a/pysages/backends/ase.py
+++ b/pysages/backends/ase.py
@@ -111,7 +111,7 @@ def take_snapshot(simulation, forces=None):
     a = atoms.cell[0]
     b = atoms.cell[1]
     c = atoms.cell[2]
-    H = ((a[0], b[0], c[0]), (a[1], b[1], c[1]), (a[2], b[2], c[2]))
+    H = ((a[0], a[1], a[2]), (b[0], b[1], b[2]), (c[0], c[1], c[2]))
     origin = (0.0, 0.0, 0.0)
     dt = simulation.dt
 


### PR DESCRIPTION
Storing the cell from an ASE MD environment currently will perform a transpose unintentionally. This error is usually harmless, but will cause problems when the cell is triclinic and restarting from a previous state. This pull request fixes this problem.