### PR TITLE
Enable the continuous GeM calc.

### DIFF
--- a/pysages/utils/__init__.py
+++ b/pysages/utils/__init__.py
@@ -17,5 +17,5 @@ from .compat import (
     solve_pos_def,
     try_import,
 )
-from .core import ToCPU, copy, dispatch, eps, first_or_all, gaussian, identity
+from .core import ToCPU, copy, dispatch, eps, first_or_all, gaussian, identity, row_sum
 from .transformations import quaternion_from_euler, quaternion_matrix


### PR DESCRIPTION
The continuous calculation of GeM is enabled by adding a new score as defined in Eq. A1-A2 in ["Local-order metric for condensed-phase environments"](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.97.064105).