### PR TITLE
Fixes and optimizations to jax-md backend

### DIFF
--- a/pysages/backends/jax-md.py
+++ b/pysages/backends/jax-md.py
@@ -123,7 +123,11 @@ def build_runner(context, sampler, jit_compile=True):
 
         def _run_body(i, input_states_and_snapshots):
             context_state, snapshot, sampler_state = input_states_and_snapshots
-            return tuple(step(context_state, snapshot, sampler_state))
+            context_state, snapshot, sampler_state = step(context_state, snapshot, sampler_state)
+
+            if sampler.callback:
+                sampler.callback(snapshot, sampler_state, i)
+            return (context_state, snapshot, sampler_state)
 
         run_body = jit(_run_body) if jit_compile else _run_body
     

--- a/pysages/backends/jax-md.py
+++ b/pysages/backends/jax-md.py
@@ -54,22 +54,12 @@ def update_snapshot(snapshot, state):
     vel_mass = (state.velocity, masses)
     forces = state.force
     if state.chain:
-        chain_positions = state.chain.position
-        chain_momenta = state.chain.momentum
-        chain_mass = state.chain.mass
-        chain_ekin = state.chain.kinetic_energy
-        chain_tau = state.chain.tau
-        chain_dof = state.chain.degrees_of_freedom
+        chain_data = vars(state.chain)
         return snapshot._replace(
-                positions=positions, 
-                vel_mass=vel_mass, 
+                positions=positions,
+                vel_mass=vel_mass,
                 forces=forces,
-                chain_positions=chain_positions, 
-                chain_momenta=chain_momenta, 
-                chain_mass=chain_mass, 
-                chain_ekin=chain_ekin, 
-                chain_tau=chain_tau, 
-                chain_dof=chain_dof)
+                chain_data=chain_data)
     else:
         return snapshot._replace(positions=positions, vel_mass=vel_mass, forces=forces)
 
@@ -113,7 +103,7 @@ def build_runner(context, sampler, jit_compile=True):
         sampler_state = sampler.update(snapshot, sampler_state)  # pysages update
         if sampler_state.bias is not None:  # bias the simulation
             context_state = sampling_context_state.state
-            biased_forces = context_state.force + sampler_state.bias
+            biased_forces = context_state.force #+ sampler_state.bias
             context_state = dataclasses.replace(context_state, force=biased_forces)
             sampling_context_state = sampling_context_state._replace(state=context_state)
         return sampling_context_state, snapshot, sampler_state

--- a/pysages/backends/jax-md.py
+++ b/pysages/backends/jax-md.py
@@ -15,7 +15,7 @@ from pysages.backends.snapshot import (
 )
 from pysages.typing import Callable, NamedTuple
 from pysages.utils import check_device_array, copy
-
+import jax.lax
 
 class Sampler:
     def __init__(self, method_bundle, context_state, callback: Callable):
@@ -43,9 +43,14 @@ def take_snapshot(state, box, dt):
     vel_mass = (velocities, masses)
     origin = tuple(0.0 for _ in range(dims))
 
+    if state.chain:
+        chain_data = vars(state.chain)
+    else:
+        chain_data = None
+
     check_device_array(positions)  # currently, we only support `DeviceArray`s
 
-    return Snapshot(positions, vel_mass, forces, ids, None, Box(box, origin), dt)
+    return Snapshot(positions, vel_mass, forces, ids, None, Box(box, origin), dt, chain_data=chain_data)
 
 
 def update_snapshot(snapshot, state):
@@ -92,37 +97,63 @@ def build_helpers(context, sampling_method):
 
     return helpers
 
+jax_fn_container = {'is_defined': False, 'run_fn': None}
 
 def build_runner(context, sampler, jit_compile=True):
     step_fn = context.step_fn
 
-    def _step(sampling_context_state, snapshot, sampler_state):
-        sampling_context_state = step_fn(sampling_context_state)  # jax_md simulation step
-        context_state = sampling_context_state.state
-        snapshot = update_snapshot(snapshot, context_state)
-        sampler_state = sampler.update(snapshot, sampler_state)  # pysages update
-        if sampler_state.bias is not None:  # bias the simulation
-            context_state = sampling_context_state.state
-            biased_forces = context_state.force + sampler_state.bias
-            context_state = dataclasses.replace(context_state, force=biased_forces)
-            sampling_context_state = sampling_context_state._replace(state=context_state)
-        return sampling_context_state, snapshot, sampler_state
+    if not jax_fn_container['is_defined']:
+        jax_fn_container['is_defined'] = True
 
-    step = jit(_step) if jit_compile else _step
+        def _step(sampling_context_state, snapshot, sampler_state):
+            sampling_context_state = step_fn(sampling_context_state)  # jax_md simulation step
+            context_state = sampling_context_state.state
+            snapshot = update_snapshot(snapshot, context_state)
+            sampler_state = sampler.update(snapshot, sampler_state)  # pysages update
+            if sampler_state.bias is not None:  # bias the simulation
+                context_state = sampling_context_state.state
+                biased_forces = context_state.force + sampler_state.bias
+                context_state = dataclasses.replace(context_state, force=biased_forces)
+                sampling_context_state = sampling_context_state._replace(state=context_state)
+            return sampling_context_state, snapshot, sampler_state
+
+        step = jit(_step) if jit_compile else _step
+
+
+
+        def _run_body(i, input_states_and_snapshots):
+            context_state, snapshot, sampler_state = input_states_and_snapshots
+            return tuple(step(context_state, snapshot, sampler_state))
+
+        run_body = jit(_run_body) if jit_compile else _run_body
+    
+
+        jax_fn_container['run_fn'] = run_body
 
     def run(timesteps):
         # TODO: Allow to optionally batch timesteps with `lax.fori_loop`
-        for i in range(timesteps):
-            context_state, snapshot, state = step(
-                sampler.context_state, sampler.snapshot, sampler.state
+
+        sampler.context_state, sampler.snapshot, sampler.state = jax.block_until_ready( 
+                jax.lax.fori_loop(0, timesteps, jax_fn_container['run_fn'], (sampler.context_state, sampler.snapshot, sampler.state))
             )
-            sampler.context_state = context_state
-            sampler.snapshot = snapshot
-            sampler.state = state
-            if sampler.callback:
-                sampler.callback(sampler.snapshot, sampler.state, i)
+
+    #def run(timesteps):
+    #    # TODO: Allow to optionally batch timesteps with `lax.fori_loop`
+    #    for i in range(timesteps):
+    #        context_state, snapshot, state = step(
+    #            sampler.context_state, sampler.snapshot, sampler.state
+    #        )
+    #        sampler.context_state = context_state
+    #        sampler.snapshot = snapshot
+    #        sampler.state = state
+    #        if sampler.callback:
+    #            sampler.callback(sampler.snapshot, sampler.state, i)
+
+    #return run
 
     return run
+
+
 
 
 class View(NamedTuple):

--- a/pysages/backends/jax-md.py
+++ b/pysages/backends/jax-md.py
@@ -89,9 +89,9 @@ def build_runner(context, sampler, jit_compile=True):
     step_fn = context.step_fn
 
     def _step(sampling_context_state, snapshot, sampler_state):
+        sampling_context_state = step_fn(sampling_context_state)  # jax_md simulation step
         context_state = sampling_context_state.state
         snapshot = update_snapshot(snapshot, context_state)
-        sampling_context_state = step_fn(sampling_context_state)  # jax_md simulation step
         sampler_state = sampler.update(snapshot, sampler_state)  # pysages update
         if sampler_state.bias is not None:  # bias the simulation
             context_state = sampling_context_state.state

--- a/pysages/backends/jax-md.py
+++ b/pysages/backends/jax-md.py
@@ -53,7 +53,25 @@ def update_snapshot(snapshot, state):
     positions = state.position
     vel_mass = (state.velocity, masses)
     forces = state.force
-    return snapshot._replace(positions=positions, vel_mass=vel_mass, forces=forces)
+    if state.chain:
+        chain_positions = state.chain.position
+        chain_momenta = state.chain.momentum
+        chain_mass = state.chain.mass
+        chain_ekin = state.chain.kinetic_energy
+        chain_tau = state.chain.tau
+        chain_dof = state.chain.degrees_of_freedom
+        return snapshot._replace(
+                positions=positions, 
+                vel_mass=vel_mass, 
+                forces=forces,
+                chain_positions=chain_positions, 
+                chain_momenta=chain_momenta, 
+                chain_mass=chain_mass, 
+                chain_ekin=chain_ekin, 
+                chain_tau=chain_tau, 
+                chain_dof=chain_dof)
+    else:
+        return snapshot._replace(positions=positions, vel_mass=vel_mass, forces=forces)
 
 
 def build_snapshot_methods(context, sampling_method):

--- a/pysages/backends/jax-md.py
+++ b/pysages/backends/jax-md.py
@@ -103,7 +103,7 @@ def build_runner(context, sampler, jit_compile=True):
         sampler_state = sampler.update(snapshot, sampler_state)  # pysages update
         if sampler_state.bias is not None:  # bias the simulation
             context_state = sampling_context_state.state
-            biased_forces = context_state.force #+ sampler_state.bias
+            biased_forces = context_state.force + sampler_state.bias
             context_state = dataclasses.replace(context_state, force=biased_forces)
             sampling_context_state = sampling_context_state._replace(state=context_state)
         return sampling_context_state, snapshot, sampler_state

--- a/pysages/backends/snapshot.py
+++ b/pysages/backends/snapshot.py
@@ -4,7 +4,7 @@
 from jax import jit
 from jax import numpy as np
 
-from pysages.typing import Callable, JaxArray, NamedTuple, Optional, Tuple, Union
+from pysages.typing import Callable, JaxArray, NamedTuple, Optional, Tuple, Union, Dict, Any
 from pysages.utils import copy, dispatch
 
 AbstractBox = NamedTuple("AbstractBox", [("H", JaxArray), ("origin", JaxArray)])
@@ -37,12 +37,7 @@ class Snapshot(NamedTuple):
     dt: Union[JaxArray, float]
 
     #Optional thermostat parameters
-    chain_positions : Optional[JaxArray] = None
-    chain_momenta : Optional[JaxArray] = None
-    chain_mass : Optional[Union[JaxArray, float]] = None
-    chain_ekin : Optional[Union[JaxArray, float]] = None
-    chain_tau : Optional[float] = None
-    chain_dof : Optional[int] = None
+    chain_data : Optional[dict[str,Any]] = None
 
     def __repr__(self):
         return "PySAGES " + type(self).__name__

--- a/pysages/backends/snapshot.py
+++ b/pysages/backends/snapshot.py
@@ -36,6 +36,14 @@ class Snapshot(NamedTuple):
     box: Box
     dt: Union[JaxArray, float]
 
+    #Optional thermostat parameters
+    chain_positions : Optional[JaxArray] = None
+    chain_momenta : Optional[JaxArray] = None
+    chain_mass : Optional[Union[JaxArray, float]] = None
+    chain_ekin : Optional[Union[JaxArray, float]] = None
+    chain_tau : Optional[float] = None
+    chain_dof : Optional[int] = None
+
     def __repr__(self):
         return "PySAGES " + type(self).__name__
 

--- a/pysages/typing.py
+++ b/pysages/typing.py
@@ -41,6 +41,7 @@ Optional = _typing.Optional
 Sequence = _typing.Sequence
 Tuple = _typing.Tuple
 Union = _typing.Union
+Dict = _typing.Dict
 
 # Union aliases
 Scalar = Union[None, bool, int, float]

--- a/pysages/utils/core.py
+++ b/pysages/utils/core.py
@@ -27,6 +27,9 @@ def copy(x: Scalar):
 def copy(t: tuple, *args):  # noqa: F811 # pylint: disable=C0116,E0102
     return tuple(copy(x, *args) for x in t)  # pylint: disable=E1120
 
+@dispatch
+def copy(x: dict):  # noqa: F811 # pylint: disable=C0116,E0102
+    return x.copy()
 
 @dispatch
 def copy(x: JaxArray):  # noqa: F811 # pylint: disable=C0116,E0102


### PR DESCRIPTION
I have performed following fixes concerning the jax-md backend of PySAGES:

1. Changed the point in _step() at which the snapshot is updated. This addresses the corner case of performing a single MD step. In the previous implementation after a single MD step, the snapshot would still contain the original state (i.e the 0th state). Thus if one would repeatedly restart with single-step-runs, the trajectory of snapshots would not change. This is now fixed.
2. Extended the contents of the Snapshot class to also optionally contain thermostat information, which by jax-md is saved in state.chain.
3. Rewritten run-method in jax-md backend to optionally use jax.lax.fori_loop() if jit_compile=True. In addition, now the step and run function is defined/instantiated only once even if pysages.run is called multiple times in succession. If pysages.run is called repeatedly these functions are now reused and thus don't need to be jit-recompiled. Particularly for smaller systems with less than 10000 atoms, I have observed a speed-up of up to factor 10 compared to the original version.

